### PR TITLE
Assorted automake refreshes and compile fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
-AC_INIT(src/curlpp/cURLpp.cpp)
-dnl AC_CONFIG_AUX_DIR(config)
-AM_CONFIG_HEADER(include/curlpp/config.h)
-AC_PREREQ(2.59)
-
+AC_PREREQ([2.59])
 dnl
 dnl figure out the libcurl version
-VERSION=`sed -ne 's/^#define LIBCURLPP_VERSION "\(.*\)"/\1/p' ${srcdir}/include/curlpp/cURLpp.hpp`
-AM_INIT_AUTOMAKE(curlpp,$VERSION)
-AC_SUBST(VERSION)
+AC_INIT([curlpp], m4_esyscmd_s([sed -ne 's/^#define LIBCURLPP_VERSION "\(.*\)"/\1/p' include/curlpp/cURLpp.hpp]))
+
+AC_CONFIG_SRCDIR(src/curlpp/cURLpp.cpp)
+dnl AC_CONFIG_AUX_DIR(config)
+AM_CONFIG_HEADER(include/curlpp/config.h)
+
+AM_INIT_AUTOMAKE(foreign)
 
 RPM_VERSION=$VERSION
 AC_SUBST(RPM_VERSION)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -85,7 +85,7 @@ example24_SOURCES = example24.cpp
 
 AM_LDFLAGS = -L../src/curlpp/ -lcurlpp -static 
 
-INCLUDES = -I$(top_builddir)/include
+AM_CPPFLAGS = -I$(top_builddir)/include
 
 
 

--- a/examples/example21.cpp
+++ b/examples/example21.cpp
@@ -39,23 +39,6 @@
 #include <curlpp/Options.hpp>
 #include <curlpp/Exception.hpp>
  
-/*
-   anonymous namespace to prevent name clash in case other examples using the same global entities
-   would be compiled in the same project
-*/
-namespace
-{
-
-char *data = NULL;
-
-size_t readData(char *buffer, size_t size, size_t nitems)
-{
-  strncpy(buffer, data, size * nitems);
-  return size * nitems;
-}
-
-} // namespace
-
 int main(int argc, char *argv[])
 {
   if(argc != 3) {

--- a/src/curlpp/Makefile.am
+++ b/src/curlpp/Makefile.am
@@ -6,7 +6,7 @@ if MAINTENER_CODE
 maintener_source = 
 endif
 
-INCLUDES = -I$(top_builddir)/include/curlpp -I$(top_builddir)/include
+AM_CPPFLAGS = -I$(top_builddir)/include/curlpp -I$(top_builddir)/include
 
 sources = \
 	cURLpp.cpp  \

--- a/src/curlpp/internal/Makefile.am
+++ b/src/curlpp/internal/Makefile.am
@@ -4,7 +4,7 @@ if MAINTENER_CODE
 maintener_source = 
 endif
 
-INCLUDES = -I$(top_builddir)/include/curlpp -I$(top_builddir)/include/curlpp/internal -I$(top_builddir)/include
+AM_CPPFLAGS = -I$(top_builddir)/include/curlpp -I$(top_builddir)/include/curlpp/internal -I$(top_builddir)/include
 
 sources = \
 	CurlHandle.cpp \

--- a/src/utilspp/Makefile.am
+++ b/src/utilspp/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES = libutilspp.la
 
-INCLUDES = -I$(top_builddir)/include
+AM_CPPFLAGS = -I$(top_builddir)/include
 
 libutilspp_la_SOURCES = \
 	LifetimeLibrary.cpp \


### PR DESCRIPTION
  - Pass version into AC_INIT as per modern automake
  - Use m4_esyscmd_s in AC_INIT to run shell
  - Set curlpp as foreign in AM_INIT_AUTOMAKE so we do not require README
  - INCLUDES was renamed AM_CPPFLAGS in modern automake
  - Removed unused method and variable in anonymous namespace