### PR TITLE
Switch from istream::readsome to istream::read

### DIFF
--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -77,8 +77,9 @@ struct Callbacks
 	static size_t
 	StreamReadCallback(char * buffer, size_t size, size_t nitems, std::istream * stream)
 	{
-		size_t realread = stream->readsome(buffer, static_cast<std::streamsize>(size * nitems));
-		if(!(*stream))
+		stream->read(buffer, static_cast<std::streamsize>(size * nitems));
+		size_t realread = stream->gcount();
+		if(!realread && !(*stream))
 			realread = CURL_READFUNC_ABORT;
 
 		return realread;


### PR DESCRIPTION
The answer at http://stackoverflow.com/a/27098504/25507 suggests that
readsome is "fairly useless" and "highly implementation-specific," so
read seems better.

This fixes an issue we were having with file uploads hanging and
eventually timing out (issue #9).