### PR TITLE
Fixed references to config.win32.h and config.h.

### DIFF
--- a/include/curlpp/internal/global.h
+++ b/include/curlpp/internal/global.h
@@ -25,9 +25,9 @@
 #define CURLPP_GLOBAL_H
 
 #ifndef HAVE_CONFIG_H
-	#include "curlpp/config.win32.h"
+	#include "../config.win32.h"
 #else
-	#include "curlpp/config.h"
+	#include "../config.h"
 #endif
 
 #endif // #ifndef CURLPP_GLOBAL_H


### PR DESCRIPTION
I'm not sure that this is right, but this seems to fix compile errors I was getting. include/curlpp/internal/global.h was referencing header files in the folder include/curlpp/internal/curlpp, which doesn't exist, so I changed it to include/curlpp/internal/, which contains files the the name it was trying to locate. I'm gessing global.h used to be in include/, but was moved, or something similar.