### PR TITLE
Fixed linkage of ccurlcpp::UnsetOption::UnsetOption

### DIFF
--- a/include/curlpp/internal/global.h
+++ b/include/curlpp/internal/global.h
@@ -25,9 +25,9 @@
 #define CURLPP_GLOBAL_H
 
 #ifndef HAVE_CONFIG_H
-	#include "curlpp/config.win32.h"
+	#include "../config.win32.h"
 #else
-	#include "curlpp/config.h"
+	#include "../config.h"
 #endif
 
 #endif // #ifndef CURLPP_GLOBAL_H


### PR DESCRIPTION
This fix was proposed by Mike Kinghan on Stack Overflow. Sorry for the multiple pull requests, but I wanted to keep this one separate as I'm less sure of it. [This is a link to answer on SO.](http://stackoverflow.com/a/33506322/1526048)