### PR TITLE
Switch from std::auto_ptr to std::shared_ptr

### DIFF
--- a/include/curlpp/Easy.hpp
+++ b/include/curlpp/Easy.hpp
@@ -75,7 +75,7 @@ namespace curlpp
 		* This function will set the option value of the OptionBase to the 
 		* handle. 
 		*/
-		virtual void setOpt(std::shared_ptr<OptionBase> option);
+		virtual void setOpt(std::unique_ptr<OptionBase> option);
 
 		/**
 		* This function will set the option value of the OptionBase to the 

--- a/include/curlpp/Easy.hpp
+++ b/include/curlpp/Easy.hpp
@@ -56,7 +56,7 @@ namespace curlpp
 		* This allow to have a handle, which might have
 		* some option set, but we don't care about them.
 		*/
-		Easy(std::auto_ptr<internal::CurlHandle> handle);
+		Easy(std::shared_ptr<internal::CurlHandle> handle);
 		virtual ~Easy();
 
 		/**
@@ -75,7 +75,7 @@ namespace curlpp
 		* This function will set the option value of the OptionBase to the 
 		* handle. 
 		*/
-		virtual void setOpt(std::auto_ptr<OptionBase> option);
+		virtual void setOpt(std::shared_ptr<OptionBase> option);
 
 		/**
 		* This function will set the option value of the OptionBase to the 
@@ -151,7 +151,7 @@ namespace curlpp
 		template<typename T>
 		void getInfo(CURLINFO info, T & value) const;
 
-		std::auto_ptr<internal::CurlHandle> mCurl;
+		std::shared_ptr<internal::CurlHandle> mCurl;
 
 		internal::OptionList mOptions;
 

--- a/include/curlpp/internal/CurlHandle.hpp
+++ b/include/curlpp/internal/CurlHandle.hpp
@@ -55,7 +55,7 @@ namespace internal
 		CurlHandle();
 		CurlHandle(CURL * handle);
 
-		std::auto_ptr<CurlHandle> clone() const;
+		std::shared_ptr<CurlHandle> clone() const;
 
 		/**
 		* Calls curl_easy_perform on the handle and throws exceptions on errors.

--- a/include/utilspp/clone_ptr.hpp
+++ b/include/utilspp/clone_ptr.hpp
@@ -33,7 +33,7 @@ namespace utilspp
   // ensure that when we go out of scope, it will delete the 
   // pointer.
   // 
-  // However, contrary to the std::auto_ptr, instead of 
+  // However, contrary to the std::shared_ptr, instead of 
   // transfering the ownership on copy construction, it clones 
   // the content. This means that we can have STL containers
   // that uses that class for managing the pointers.

--- a/include/utilspp/functor/Binder.hpp
+++ b/include/utilspp/functor/Binder.hpp
@@ -99,7 +99,7 @@ namespace utilspp
     typedef Functor<R, TList> Incoming;
     typedef Functor<R, typename TList::tail> Outgoing;
     
-    return Outgoing(std::auto_ptr<typename Outgoing::Impl>(new BinderFirst<Incoming>(fun, bound)));
+    return Outgoing(std::shared_ptr<typename Outgoing::Impl>(new BinderFirst<Incoming>(fun, bound)));
   }
     
 }

--- a/include/utilspp/functor/Functor.hpp
+++ b/include/utilspp/functor/Functor.hpp
@@ -54,13 +54,13 @@ namespace utilspp
       : mImpl()
     {}
 
-    Functor(std::auto_ptr<Impl> impl) 
+    Functor(std::shared_ptr<Impl> impl) 
       : mImpl(impl)
     {}
 
     Functor & operator=(const Functor & functor)
     {
-      mImpl = std::auto_ptr<Impl>(functor.mImpl->clone());
+      mImpl = std::shared_ptr<Impl>(functor.mImpl->clone());
       return (*this);
     }
 
@@ -142,7 +142,7 @@ namespace utilspp
     {return (*mImpl)(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);}
 
   private:
-    std::auto_ptr<Impl> mImpl;
+    std::shared_ptr<Impl> mImpl;
   };
   
   template<typename Fun>

--- a/src/curlpp/Easy.cpp
+++ b/src/curlpp/Easy.cpp
@@ -64,7 +64,7 @@ curlpp::Easy::setOpt(const OptionBase & option)
 
 
 void
-curlpp::Easy::setOpt(std::shared_ptr<OptionBase> option)
+curlpp::Easy::setOpt(std::unique_ptr<OptionBase> option)
 {
 	option->updateHandleToMe(mCurl.get());
 	mOptions.setOpt(option.get());    

--- a/src/curlpp/Easy.cpp
+++ b/src/curlpp/Easy.cpp
@@ -33,7 +33,7 @@ curlpp::Easy::Easy()
 {}
 
 
-curlpp::Easy::Easy(std::auto_ptr<internal::CurlHandle> handle)
+curlpp::Easy::Easy(std::shared_ptr<internal::CurlHandle> handle)
   : mCurl(handle)
 {}
 
@@ -64,10 +64,10 @@ curlpp::Easy::setOpt(const OptionBase & option)
 
 
 void
-curlpp::Easy::setOpt(std::auto_ptr<OptionBase> option)
+curlpp::Easy::setOpt(std::shared_ptr<OptionBase> option)
 {
 	option->updateHandleToMe(mCurl.get());
-	mOptions.setOpt(option.release());    
+	mOptions.setOpt(option.get());    
 }
 
 

--- a/src/curlpp/internal/CurlHandle.cpp
+++ b/src/curlpp/internal/CurlHandle.cpp
@@ -34,7 +34,7 @@
 
 
 using std::memset;
-using std::auto_ptr;
+using std::shared_ptr;
 
 
 namespace curlpp
@@ -89,12 +89,12 @@ CurlHandle::CurlHandle(CURL * handle)
 }
 
 
-std::auto_ptr<CurlHandle> 
+std::shared_ptr<CurlHandle> 
 CurlHandle::clone() const
 {
 	CURL * cHandle = curl_easy_duphandle(mCurl);
 	runtimeAssert("Error when trying to curl_easy_duphandle() a handle", cHandle != NULL);
-	auto_ptr<CurlHandle> newHandle(new CurlHandle(cHandle));
+	shared_ptr<CurlHandle> newHandle(new CurlHandle(cHandle));
 
 	return newHandle;
 }
@@ -333,7 +333,7 @@ CurlHandle::throwException()
 {
   if(mException) 
   {
-    std::auto_ptr< cURLpp::CallbackExceptionBase > e(mException);
+    std::shared_ptr< cURLpp::CallbackExceptionBase > e(mException);
     mException = NULL;
     e->throwMe();
   }


### PR DESCRIPTION
This change is made as newer  gcc/g++ compiler has std::auto_ptr as deprecated. As explained by issue #13. 