### PR TITLE
No C++11 flag set but C++11 is used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,18 @@ CXXFLAGS="$CXXFLAGS -Werror "
 )
 
 
+AC_MSG_CHECKING([enable C++11 compiler])
+AC_ARG_ENABLE(ewarning,
+[  --enable-ewarning       Build with C++11 compiler [default=yes]],
+[ 
+AC_MSG_RESULT(no)
+],
+[
+AC_MSG_RESULT(yes)
+CXXFLAGS="$CXXFLAGS -std=c++11 "
+]
+)
+
 
 AC_MSG_CHECKING([whether to enable the maintener code])
 AC_ARG_ENABLE(maintener,


### PR DESCRIPTION
So now code doesn't compile after `./autogen.sh` and `./configure`. Added entry to configuration tool to add the flag.