### PR TITLE
Fix build on Debian 7.11/cmake 2.8.11.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(WIN32)
         #
         # for non-windows platform we try to keep cmake 2.8 support
         # since entreprise distribution tends to have 2.8 version.
-        add_compile_options(-std=c++11)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     else()
         # c++ 11 support from cmake 3.1 or newer
         set(CMAKE_CXX_STANDARD 11) # C++11...


### PR DESCRIPTION
Just needed to install curlpp on an older Debian 7 system. Its cmake doesn't yet support _add_compile_options_. Not sure if this is a step backwards in terms of niceness, but at least it compiles.