### PR TITLE
Fixed memory leak when curl_slist is passed to wrapper

### DIFF
--- a/src/curlpp/internal/SList.cpp
+++ b/src/curlpp/internal/SList.cpp
@@ -21,7 +21,7 @@ SList::SList(const SList & rhs)
 
 
 SList::SList(curl_slist * list)
-	: mList(NULL)
+	: mList(list)
 {
 	constructFrom(list);
 }


### PR DESCRIPTION
When the cookie engine is turned on some bytes are leaked because the actual list by curl is never freed.

The current fix makes sure that the update() method can free it.