### PR TITLE
Added XferInfo function callback

### DIFF
--- a/include/curlpp/Options.hpp
+++ b/include/curlpp/Options.hpp
@@ -161,6 +161,15 @@ namespace options
 	typedef curlpp::OptionTrait<curlpp::types::SslCtxFunctionFunctor, CURLOPT_SSL_CTX_FUNCTION>
 		SslCtxFunction;
 
+#if LIBCURL_VERSION_NUM >= 0x072000
+	typedef curlpp::OptionTrait<curlpp::types::XferInfoFunctionFunctor, CURLOPT_XFERINFOFUNCTION>
+		XferInfoFunction;
+#else
+#ifdef CURLPP_ALLOW_NOT_AVAILABLE
+	typedef curlpp::NotAvailableOptionTrait<curlpp::types::XferInfoFunctionFunctor> XferInfoFunction;
+#endif // CURLPP_ALLOW_NOT_AVAILABLE
+#endif // LIBCURL_VERSION_NUM
+
 	/**
 	* Error options.
 	*/

--- a/include/curlpp/Types.hpp
+++ b/include/curlpp/Types.hpp
@@ -27,7 +27,7 @@
 
 
 #include <functional>
-
+#include <curl/system.h>
 
 namespace curlpp
 {
@@ -39,10 +39,10 @@ namespace types
 	typedef std::function< size_t(char*, size_t, size_t) > WriteFunctionFunctor;
 	typedef std::function< size_t(char*, size_t, size_t) > ReadFunctionFunctor;
 	/// DebugFunctor related typedefs
-        typedef std::function< int(curl_infotype, char *, size_t) > DebugFunctionFunctor;
-        typedef std::function< CURLcode(void *) > SslCtxFunctionFunctor;
-	typedef std::function< int(double, double, double, double)> ProgressFunctionFunctor;
-  
+	typedef std::function< int(curl_infotype, char *, size_t) > DebugFunctionFunctor;
+	typedef std::function< CURLcode(void *) > SslCtxFunctionFunctor;
+	typedef std::function< int(double, double, double, double) > ProgressFunctionFunctor;
+	typedef std::function< int(curl_off_t, curl_off_t, curl_off_t, curl_off_t) > XferInfoFunctionFunctor;
 } // namespace types
 
 namespace Types = types;

--- a/include/curlpp/Types.hpp
+++ b/include/curlpp/Types.hpp
@@ -27,7 +27,7 @@
 
 
 #include <functional>
-#include <curl/system.h>
+#include <curl/curl.h>
 
 namespace curlpp
 {

--- a/include/curlpp/internal/CurlHandle.hpp
+++ b/include/curlpp/internal/CurlHandle.hpp
@@ -136,6 +136,17 @@ namespace internal
 			mProgressFunctor = functor;
 		}
 
+#if LIBCURL_VERSION_NUM >= 0x072000
+		int executeXferInfoFunctor(	curl_off_t dltotal,
+									curl_off_t dlnow,
+									curl_off_t ultotal,
+									curl_off_t ulnow);
+
+		void setXferInfoFunctor(curlpp::types::XferInfoFunctionFunctor functor)
+		{
+			mXferInfoFunctor = functor;
+		}
+#endif // LIBCURL_VERSION_NUM
 
 		int executeDebugFunctor(curl_infotype, char *, size_t);
 
@@ -183,6 +194,9 @@ namespace internal
 		curlpp::types::WriteFunctionFunctor mHeaderFunctor;
 		curlpp::types::ReadFunctionFunctor mReadFunctor;
 		curlpp::types::ProgressFunctionFunctor mProgressFunctor;
+#if LIBCURL_VERSION_NUM >= 0x072000
+		curlpp::types::XferInfoFunctionFunctor mXferInfoFunctor;
+#endif // LIBCURL_VERSION_NUM
 		curlpp::types::DebugFunctionFunctor mDebugFunctor;
 		curlpp::types::SslCtxFunctionFunctor mSslFunctor;
 		curlpp::CallbackExceptionBase * mException;

--- a/include/curlpp/internal/OptionSetter.hpp
+++ b/include/curlpp/internal/OptionSetter.hpp
@@ -347,6 +347,28 @@ namespace internal
 
 #endif // #ifdef HAVE_BOOST
 
+#if LIBCURL_VERSION_NUM >= 0x072000
+	/**
+	* Specialization.
+	*/
+
+	template<>
+	class OptionSetter<curlpp::types::XferInfoFunctionFunctor,
+																CURLOPT_XFERINFOFUNCTION>
+	{
+
+	public:
+
+		typedef curlpp::types::XferInfoFunctionFunctor
+			OptionValueType;
+
+		typedef curlpp::internal::OptionContainerType<OptionValueType>::HandleOptionType
+			ParamType;
+
+		static void setOpt(internal::CurlHandle * handle, ParamType value);
+
+	};
+#endif // LIBCURL_VERSION_NUM
 
 	/**
 	* Specialization.

--- a/src/curlpp/internal/CurlHandle.cpp
+++ b/src/curlpp/internal/CurlHandle.cpp
@@ -270,6 +270,37 @@ CurlHandle::executeProgressFunctor(double dltotal,
 	return CURLE_ABORTED_BY_CALLBACK;
 }
 
+#if LIBCURL_VERSION_NUM >= 0x072000
+int
+CurlHandle::executeXferInfoFunctor(	curl_off_t dltotal,
+									curl_off_t dlnow,
+									curl_off_t ultotal,
+									curl_off_t ulnow)
+{
+	if (!mXferInfoFunctor)
+	{
+		setException(new CallbackException<curlpp::LogicError>(curlpp::LogicError("Null XferInfo functor")));
+		return CURLE_ABORTED_BY_CALLBACK;
+	}
+
+	try
+	{
+		return mXferInfoFunctor(dltotal, dlnow, ultotal, ulnow);
+	}
+
+	catch (curlpp::CallbackExceptionBase * e)
+	{
+		setException(e);
+	}
+
+	catch (...)
+	{
+		setException(new CallbackException<curlpp::UnknowException>(curlpp::UnknowException()));
+	}
+
+	return CURLE_ABORTED_BY_CALLBACK;
+}
+#endif // LIBCURL_VERSION_NUM
 
 int 
 CurlHandle::executeDebugFunctor(curl_infotype info, char * buffer, size_t size)

--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -93,6 +93,17 @@ struct Callbacks
 		return handle->executeProgressFunctor(dltotal, dlnow, ultotal, ulnow);
 	};
 
+#if LIBCURL_VERSION_NUM >= 0x072000
+	static int
+	XferInfoCallback(internal::CurlHandle * handle,
+											curl_off_t dltotal,
+											curl_off_t dlnow,
+											curl_off_t ultotal,
+											curl_off_t ulnow)
+	{
+		return handle->executeXferInfoFunctor(dltotal, dlnow, ultotal, ulnow);
+	};
+#endif // LIBCURL_VERSION_NUM
 
 	static int
 	DebugCallback(CURL *,
@@ -222,6 +233,15 @@ void OptionSetter<curlpp::types::BoostProgressFunction, CURLOPT_PROGRESSFUNCTION
 
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x072000
+void OptionSetter<curlpp::types::XferInfoFunctionFunctor, CURLOPT_XFERINFOFUNCTION>
+::setOpt(internal::CurlHandle * handle, ParamType value)
+{
+	handle->option(CURLOPT_XFERINFOFUNCTION, Callbacks::XferInfoCallback);
+	handle->option(CURLOPT_XFERINFODATA, handle);
+	handle->setXferInfoFunctor(value);
+}
+#endif // LIBCURL_VERSION_NUM
 
 void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_HEADERFUNCTION>
 ::setOpt(internal::CurlHandle * handle, ParamType value)


### PR DESCRIPTION
Added the new (since 7.32.0) progress function callback XFERINFOFUNCTION.
I didn't include a Boost callback, since it is no longer used in curlpp > 0.8
