### PR TITLE
Fix options when HAVE_BOOST is defined

### DIFF
--- a/doc/README.win32
+++ b/doc/README.win32
@@ -192,20 +192,11 @@ NOTES
     If you need OpenSSL for Windows platform take a look at http://www.slproweb.com/products/Win32OpenSSL.html
     If you installed OpenSSL downloaded from the above link you'll find .lib files of all four build categories
     in the /lib/vc directory.
-    
-    
-    Building with support for Boost
-    
-    curlpp has ability to use some features from the Boost library. If you want to build curlpp with support for Boost
-    you have to set value of BOOST_PATH user macro to your installation of Boost before building curlpp.
-    This variable is used in the project file for VC9 to find include files of Boost.
-    You also have to define preprocessor symbol HAVE_BOOST. You can do it in
-    Project/Properties/C/C++/Preprocessor/Preprocessor Definitions.
-	
+
 
     Project propery sheets
     
-    All user macros like LIBCURL_PATH, OPENSSL_PATH, BOOST_PATH, CURLPP_INCLUDE_PATH, CURLPP_LIB_PATH, WIN_SDK_DIR,
+    All user macros like LIBCURL_PATH, OPENSSL_PATH, CURLPP_INCLUDE_PATH, CURLPP_LIB_PATH, WIN_SDK_DIR,
 	CURLPP_EXAMPLES_OUT_DIR, etc. 
 	are defined in project property sheet files named 
 	curlpp.common.vsprops   - options and macros used during build of library itself and during build of examples

--- a/examples/README
+++ b/examples/README
@@ -23,7 +23,7 @@ usage.
              (SslEngineDefault)
  Example 16: HTTP POST example with HTTP Authentification.
  Example 17: Binded method functor for WriteFunction example.
- Example 18: No longer available. This used to be a boost usage example, but it's no longer relevant since c++11.
+ Example 18: No longer available. This used to be a boost usage example, but it's no longer functional since c++11.
  Example 19: Multipart/formdata HTTP POST example.
  Example 20: std::ostream usage.
  Example 21: upload example with std::istream.

--- a/examples/example18.cpp
+++ b/examples/example18.cpp
@@ -93,8 +93,11 @@ int main(int argc, char *argv[])
     // Set the writer callback to enable cURL 
     // to write result in a memory area
 #ifdef HAVE_BOOST
+    //These boost functions have been deprecated out
+    /*
     curlpp::options::BoostWriteFunction *test = new curlpp::options::BoostWriteFunction(boost::bind(&MethodClass::write, &mObject, &request, _1, _2, _3));
     request.setOpt(test);
+    */
 #endif /* HAVE_BOOST */
     
     // Setting the URL to retrive.

--- a/include/curlpp/internal/OptionSetter.hpp
+++ b/include/curlpp/internal/OptionSetter.hpp
@@ -139,32 +139,6 @@ namespace internal
 	};
 
 
-#ifdef HAVE_BOOST
-
-	/**
-	* Specialization.
-	*/
-
-	template<>
-	class OptionSetter<curlpp::types::BoostWriteFunction,
-																CURLOPT_WRITEFUNCTION>
-	{
-
-	public:
-
-		typedef curlpp::types::BoostWriteFunction
-			OptionValueType;
-
-		typedef curlpp::internal::OptionContainerType<OptionValueType>::HandleOptionType
-			ParamType;
-
-		static void setOpt(internal::CurlHandle * handle, ParamType value);
-
-	};
-
-#endif // #ifdef HAVE_BOOST
-
-
 	/**
 	* Specialization.
 	*/
@@ -228,32 +202,6 @@ namespace internal
 		static void setOpt(internal::CurlHandle * handle, ParamType value);
 
 	};
-
-
-#ifdef HAVE_BOOST
-
-	/**
-	* Specialization.
-	*/
-
-	template<>
-	class OptionSetter<curlpp::types::BoostReadFunction,
-																CURLOPT_READFUNCTION>
-	{
-
-	public:
-
-		typedef curlpp::types::BoostReadFunction
-			OptionValueType;
-
-		typedef curlpp::internal::OptionContainerType<OptionValueType>::HandleOptionType
-			ParamType;
-
-		static void setOpt(internal::CurlHandle * handle, ParamType value);
-
-	};
-
-#endif // #ifdef HAVE_BOOST
 
 
 	/**
@@ -322,32 +270,6 @@ namespace internal
 	};
 
 
-#ifdef HAVE_BOOST
-
-	/**
-	* Specialization.
-	*/
-
-	template<>
-	class OptionSetter<curlpp::types::BoostProgressFunction,
-																CURLOPT_PROGRESSFUNCTION>
-	{
-
-	public:
-
-		typedef curlpp::types::BoostProgressFunction
-			OptionValueType;
-		
-		typedef curlpp::internal::OptionContainerType<OptionValueType>::HandleOptionType
-			ParamType;
-
-		static void setOpt(internal::CurlHandle * handle, ParamType value);
-
-	};
-
-#endif // #ifdef HAVE_BOOST
-
-
 	/**
 	* Specialization.
 	*/
@@ -369,32 +291,6 @@ namespace internal
 		static void setOpt(internal::CurlHandle * handle, ParamType value);
 
 	};
-
-
-#ifdef HAVE_BOOST
-
-	/**
-	* Specialization.
-	*/
-
-	template<>
-	class OptionSetter<curlpp::types::BoostWriteFunction,
-																CURLOPT_HEADERFUNCTION>
-	{
-
-	public:
-
-		typedef curlpp::types::BoostWriteFunction
-			OptionValueType;
-
-		typedef curlpp::internal::OptionContainerType<OptionValueType>::HandleOptionType
-			ParamType;
-
-		static void setOpt(internal::CurlHandle * handle, ParamType value);
-
-	};
-
-#endif // #ifdef HAVE_BOOST
 
 
 	/**
@@ -419,32 +315,6 @@ namespace internal
 	};
 
 
-#ifdef HAVE_BOOST
-
-	/**
-	* Specialization.
-	*/
-
-	template<>
-	class OptionSetter<curlpp::types::BoostDebugFunction,
-																CURLOPT_DEBUGFUNCTION>
-	{
-
-	public:
-
-		typedef curlpp::types::BoostDebugFunction
-			OptionValueType;
-
-		typedef curlpp::internal::OptionContainerType<OptionValueType>::HandleOptionType
-			ParamType;
-
-		static void setOpt(internal::CurlHandle * handle, ParamType value);
-
-	};
-
-#endif // #ifdef HAVE_BOOST
-
-
 	/**
 	* Specialization.
 	*/
@@ -465,31 +335,6 @@ namespace internal
 		static void setOpt(internal::CurlHandle * handle, ParamType value);
 
 	};
-
-
-#ifdef HAVE_BOOST
-
-	/**
-	* Specialization.
-	*/
-
-	template<>
-	class OptionSetter<curlpp::types::BoostSslCtxFunction,
-																CURLOPT_SSL_CTX_FUNCTION>
-	{
-
-	public:
-
-		typedef curlpp::types::BoostSslCtxFunction
-			OptionValueType;
-
-		typedef curlpp::internal::OptionContainerType<OptionValueType>::HandleOptionType
-			ParamType;
-
-		static void setOpt(internal::CurlHandle * handle, ParamType value);
-	};
-
-#endif // #ifdef HAVE_BOOST
 
 
 } // namespace internal

--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -132,20 +132,6 @@ void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_WRITEFUNCTION>
 };
 
 
-#ifdef HAVE_BOOST
-
-void OptionSetter<curlpp::types::BoostWriteFunction, CURLOPT_WRITEFUNCTION>
-::setOpt(internal::CurlHandle * handle, ParamType value)
-{
-	handle->option(CURLOPT_WRITEFUNCTION, Callbacks::WriteCallback);
-	handle->option(CURLOPT_WRITEDATA, handle);
-	handle->setWriteFunctor(curlpp::types::WriteFunctionFunctor(&value,
-		&curlpp::types::BoostWriteFunction::operator()));
-};
-
-#endif
-
-
 void OptionSetter<FILE *, CURLOPT_WRITEDATA>
 ::setOpt(internal::CurlHandle * handle, ParamType value)
 {
@@ -169,19 +155,6 @@ void OptionSetter<curlpp::types::ReadFunctionFunctor, CURLOPT_READFUNCTION>
 	handle->option(CURLOPT_READDATA, handle);
 	handle->setReadFunctor(value);
 };
-
-
-#ifdef HAVE_BOOST
-
-void OptionSetter<curlpp::types::BoostReadFunction, CURLOPT_READFUNCTION>
-::setOpt(internal::CurlHandle * handle, ParamType value)
-{
-	handle->option(CURLOPT_READFUNCTION, Callbacks::ReadCallback);
-	handle->option(CURLOPT_READDATA, handle);
-	handle->setReadFunctor(value);
-};
-
-#endif
 
 
 void OptionSetter<FILE *, CURLOPT_READDATA>
@@ -210,19 +183,6 @@ void OptionSetter<curlpp::types::ProgressFunctionFunctor, CURLOPT_PROGRESSFUNCTI
 };
 
 
-#ifdef HAVE_BOOST
-
-void OptionSetter<curlpp::types::BoostProgressFunction, CURLOPT_PROGRESSFUNCTION>
-::setOpt(internal::CurlHandle * handle, ParamType value)
-{
-	handle->option(CURLOPT_PROGRESSFUNCTION, Callbacks::ProgressCallback);
-	handle->option(CURLOPT_PROGRESSDATA, handle);
-	handle->setProgressFunctor(value);
-};
-
-#endif
-
-
 void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_HEADERFUNCTION>
 ::setOpt(internal::CurlHandle * handle, ParamType value)
 {
@@ -230,19 +190,6 @@ void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_HEADERFUNCTION>
 	handle->option(CURLOPT_HEADERDATA, handle);
 	handle->setHeaderFunctor(value);
 };
-
-
-#ifdef HAVE_BOOST
-
-void OptionSetter<curlpp::types::BoostWriteFunction, CURLOPT_HEADERFUNCTION>
-::setOpt(internal::CurlHandle * handle, ParamType value)
-{
-	handle->option(CURLOPT_HEADERFUNCTION, Callbacks::HeaderCallback);
-	handle->option(CURLOPT_HEADERDATA, handle);
-	handle->setHeaderFunctor(value);
-};
-
-#endif
 
 
 void OptionSetter<curlpp::types::DebugFunctionFunctor, CURLOPT_DEBUGFUNCTION>
@@ -254,19 +201,6 @@ void OptionSetter<curlpp::types::DebugFunctionFunctor, CURLOPT_DEBUGFUNCTION>
 };
 
 
-#ifdef HAVE_BOOST
-
-void OptionSetter<curlpp::types::BoostDebugFunction, CURLOPT_DEBUGFUNCTION>
-::setOpt(internal::CurlHandle * handle, ParamType value)
-{
-	handle->option(CURLOPT_DEBUGFUNCTION, Callbacks::DebugCallback);
-	handle->option(CURLOPT_DEBUGDATA, handle);
-	handle->setDebugFunctor(value);
-};
-
-#endif
-
-
 void OptionSetter<curlpp::types::SslCtxFunctionFunctor, CURLOPT_SSL_CTX_FUNCTION>
 ::setOpt(internal::CurlHandle * handle, ParamType value)
 {
@@ -274,19 +208,6 @@ void OptionSetter<curlpp::types::SslCtxFunctionFunctor, CURLOPT_SSL_CTX_FUNCTION
 	handle->option(CURLOPT_SSL_CTX_DATA, handle);
 	handle->setSslCtxFunctor(value);
 };
-
-
-#ifdef HAVE_BOOST
-
-void OptionSetter<curlpp::types::BoostSslCtxFunction, CURLOPT_SSL_CTX_FUNCTION>
-::setOpt(internal::CurlHandle * handle, ParamType value)
-{
-	handle->option(CURLOPT_SSL_CTX_FUNCTION, Callbacks::SslCtxCallback);
-	handle->option(CURLOPT_SSL_CTX_DATA, handle);
-	handle->setSslCtxFunctor(value);
-};
-
-#endif
 
 
 }// namespace internal


### PR DESCRIPTION
When boost dependency was removed, boost options lingered for anyone who has HAVE_BOOST defined. This issue was first seen on FreeBSD 11.1-RELEASE with curlpp from ports.

Removing the erroneous boost type references fixes the issue.