### PR TITLE
fix miss reinterpreted type

### DIFF
--- a/src/curlpp/Info.cpp
+++ b/src/curlpp/Info.cpp
@@ -41,7 +41,7 @@ void InfoTypeConverter<double>::get(const curlpp::Easy& handle,
                                     double& value) {
   curl_off_t tmp;
   InfoGetter::get(handle, info, tmp);
-  value = (double)tmp;
+  value = reinterpret_cast<double&>(tmp);
 }
 
 }  // namespace curlpp


### PR DESCRIPTION
In case of option CURLINFO_CONTENT_LENGTH_DOWNLOAD, the expected return type is double

The type of tmp is curl_off_t, aka __int64
But when tmp being passed down to libcurl, the address of tmp has been cast to double*
So anything stored in tmp by libcurl should be reinterpreted to double for read
A simple type cast is not guaranteed to get the correct value