### PR TITLE
Add display name to File() as optional 4th argument.

### DIFF
--- a/include/curlpp/Form.hpp
+++ b/include/curlpp/Form.hpp
@@ -165,6 +165,17 @@ namespace FormParts
 
 		/**
 		* initialize a File part. "name" is the name of the field. 
+		* "filename" is the string that holds the filename. 
+		* "contentType" is the MIME type of the file.
+		* "displayName" is the file name to use in the form field.
+		*/
+		File(const char * name, 
+			const char * filename, 
+			const char * contentType,
+			const char * displayName);
+
+		/**
+		* initialize a File part. "name" is the name of the field. 
 		* "filename" is the string that holds the filename.
 		*/
 		File(const std::string & name, 
@@ -178,6 +189,17 @@ namespace FormParts
 		File(const std::string & name, 
 			const std::string & filename,
 			const std::string & contentType);
+
+		/**
+		* initialize a File part. "name" is the name of the field. 
+		* "filename" is the string that holds the filename. 
+		* "contentType" is the MIME type of the file.
+		* "displayName" is the file name to use in the form field.
+		*/
+		File(const std::string & name, 
+			const std::string & filename,
+			const std::string & contentType,
+			const std::string & displayName);
 
 		virtual ~File();
 
@@ -193,8 +215,9 @@ namespace FormParts
 
 	private:
 
-		const std::string mFilename; 
+		const std::string mFilename;
 		const std::string mContentType;
+		const std::string mDisplayFilename;
 
 	};
 

--- a/src/curlpp/Form.cpp
+++ b/src/curlpp/Form.cpp
@@ -107,21 +107,36 @@ curlpp::FormPart::FormPart(const std::string & name)
 curlpp::FormParts::File::File(const char * name, const char * filename)
   : FormPart(name)
   , mFilename(filename)
+  , mDisplayFilename(filename)
 {}
 
 curlpp::FormParts::File::~File()
 {}
 
-curlpp::FormParts::File::File(const char * name, const char * filename, const char * contentType)
+curlpp::FormParts::File::File(const char * name,
+			      const char * filename,
+			      const char * contentType)
   : FormPart(name)
   , mFilename(filename)
   , mContentType(contentType)
+  , mDisplayFilename(filename)
+{}
+
+curlpp::FormParts::File::File(const char * name,
+			      const char * filename,
+			      const char * contentType,
+			      const char * displayName)
+  : FormPart(name)
+  , mFilename(filename)
+  , mContentType(contentType)
+  , mDisplayFilename(displayName)
 {}
 
 curlpp::FormParts::File::File(const std::string & name, 
 			      const std::string & filename)
   : FormPart(name)
   , mFilename(filename)
+  , mDisplayFilename(filename)
 {}
   
 curlpp::FormParts::File::File(const std::string & name, 
@@ -130,6 +145,17 @@ curlpp::FormParts::File::File(const std::string & name,
   : FormPart(name)
   , mFilename(filename)
   , mContentType(contentType)
+  , mDisplayFilename(filename)
+{}
+
+curlpp::FormParts::File::File(const std::string & name, 
+			      const std::string & filename,
+			      const std::string & contentType,
+			      const std::string & displayName)
+  : FormPart(name)
+  , mFilename(filename)
+  , mContentType(contentType)
+  , mDisplayFilename(displayName)
 {}
 
 curlpp::FormParts::File *
@@ -151,6 +177,8 @@ curlpp::FormParts::File::add(::curl_httppost ** first,
 		 mName.c_str(), 
 		 CURLFORM_FILE,
 		 mFilename.c_str(),
+		 CURLFORM_FILENAME,
+		 mDisplayFilename.c_str(),
 		 CURLFORM_END );
   }
   else {
@@ -160,6 +188,8 @@ curlpp::FormParts::File::add(::curl_httppost ** first,
 		 mName.c_str(), 
 		 CURLFORM_FILE,
 		 mFilename.c_str(),
+		 CURLFORM_FILENAME,
+		 mDisplayFilename.c_str(),
 		 CURLFORM_CONTENTTYPE,
 		 mContentType.c_str(),
 		 CURLFORM_END);


### PR DESCRIPTION
This enables showing a different name file that the one read from disk.