### PR TITLE
cmake: specify INTERFACE target_include_directories and PUBLIC curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,12 +85,21 @@ endif()
 
 file(GLOB_RECURSE HeaderFileList "${CMAKE_CURRENT_SOURCE_DIR}/include/*")
 file(GLOB_RECURSE SourceFileList "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
+
 add_library(${PROJECT_NAME} SHARED ${HeaderFileList} ${SourceFileList})
-target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${CONAN_LIBS})
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
+target_link_libraries(${PROJECT_NAME} PUBLIC curl)
+if(CONAN_LIBS)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${CONAN_LIBS})
+endif()
+target_include_directories(
+    ${PROJECT_NAME}
+    INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
 add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
-
 # Make sure that on unix-platforms shared and static libraries have
 # the same root name, but different suffixes.
 #
@@ -102,7 +111,16 @@ SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NA
 # This conflicts with the "curlpp.lib" import library corresponding to "curlpp.dll",
 # so we add a "lib" prefix (which is default on other platforms anyway):
 SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES PREFIX "lib")
-target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME}_static PUBLIC curl)
+if(CONAN_LIBS)
+  target_link_libraries(${PROJECT_NAME}_static PRIVATE ${CONAN_LIBS})
+endif()
+target_include_directories(
+    ${PROJECT_NAME}_static
+    INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
 # install headers
 install(DIRECTORY include/utilspp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/utilspp")


### PR DESCRIPTION
This way, users of curlpp can simply link it by calling `target_link_libraries()` without specifying the include path explicitly.
Also, by marking curl `PUBLIC`, curlpp users don't need to specify curl in their link_libraries.
Conan, if found, is marked `PRIVATE`.