### PR TITLE
Renaming retreive to retrieve

### DIFF
--- a/include/curlpp/Easy.hpp
+++ b/include/curlpp/Easy.hpp
@@ -145,7 +145,7 @@ namespace curlpp
 
 		/**
 		* This is the function that curlpp::InfoGetter will call
-		* to retreive option.
+		* to retrieve option.
 		*/
 		template<typename T>
 		void getInfo(CURLINFO info, T & value) const;

--- a/include/curlpp/Exception.hpp
+++ b/include/curlpp/Exception.hpp
@@ -134,7 +134,7 @@ namespace curlpp
 
 
 	/**
-	* This exception is thrown when you try to retreive a value for an
+	* This exception is thrown when you try to retrieve a value for an
 	* unset option.
 	*/
 

--- a/include/curlpp/Info.hpp
+++ b/include/curlpp/Info.hpp
@@ -96,7 +96,7 @@ namespace curlpp
 
 
 	/**
-	* This is the only class that is authorized to retreive 
+	* This is the only class that is authorized to retrieve
 	* info from a curlpp::Easy class. So, this is the class
 	* you need to use when you specialize the class
 	* curlpp::InfoTypeConverter. This class is in fact used

--- a/include/curlpp/Option.hpp
+++ b/include/curlpp/Option.hpp
@@ -70,7 +70,7 @@ namespace curlpp
 
 		/**
 		* The constructor will contain an unset option value.
-		* Note that if you try to retreive the value of this option
+		* Note that if you try to retrieve the value of this option
 		* before calling the curlpp::Option::setValue function it will
 		* throw a UnsetOption exception.
 		*/
@@ -94,14 +94,14 @@ namespace curlpp
 		* This function will return the value that this option was set to.
 		*
 		* Note: if you didn't set any value by the curlpp::Option::setValue function,
-		* or the handle option value, retreived by the curlpp::Option::updateMeToHandle
+		* or the handle option value, retrieved by the curlpp::Option::updateMeToHandle
 		* function, is a unset value, it will throw a UnsetOption exception.
 		*/
 		typename Option<OptionType>::ReturnType getValue() const;
 
 		/**
 		* This function will reset the option value. That means that if you try to
-		* retreive the value of this option, or if you try to set this option to a
+		* retrieve the value of this option, or if you try to set this option to a
 		* handle, it will throw an UnsetOption exception.
 		*/
 		virtual void clear();
@@ -158,7 +158,7 @@ namespace curlpp
 
 		/**
 		* The constructor will contain an unset option value.
-		* Note that if you try to retreive the value of this option
+		* Note that if you try to retrieve the value of this option
 		* before calling the curlpp::Option::setValue function it will
 		* throw a UnsetOption exception.
 		*/
@@ -220,7 +220,7 @@ namespace curlpp
 
 		/**
 		* The constructor will contain an unset option value.
-		* Note that if you try to retreive the value of this option
+		* Note that if you try to retrieve the value of this option
 		* before calling the curlpp::Option::setValue function it will
 		* throw a UnsetOption exception.
 		*/

--- a/include/curlpp/Option.inl
+++ b/include/curlpp/Option.inl
@@ -111,7 +111,7 @@ typename Option<OptionType>::ReturnType
 Option<OptionType>::getValue() const
 {
   if(mContainer == NULL)
-    throw UnsetOption("You are trying to retreive the value of an unset option");
+    throw UnsetOption("You are trying to retrieve the value of an unset option");
 
   return mContainer->getValue();
 }


### PR DESCRIPTION
This typo causes Lintian on package production to produce a warning.