### PR TITLE
Export include path using target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(curlpp) 
+project(curlpp)
 
 
 # In response to CMake 3.0 generating warnings regarding policy CMP0042,
@@ -67,12 +67,6 @@ else()
   message(FATAL_ERROR "Could not find CURL")
 endif()
 
-# All following targets should search these directories for headers
-include_directories( 
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CURL_INCLUDE_DIRS}
-)
-
 #########################################################################################
 # Define Targets
 
@@ -87,6 +81,12 @@ file(GLOB_RECURSE HeaderFileList "${CMAKE_CURRENT_SOURCE_DIR}/include/*")
 file(GLOB_RECURSE SourceFileList "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
 add_library(${PROJECT_NAME} SHARED ${HeaderFileList} ${SourceFileList})
 target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${CONAN_LIBS})
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CURL_INCLUDE_DIRS}
+    )
+
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
 
 add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
@@ -95,7 +95,7 @@ add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
 # the same root name, but different suffixes.
 #
 #  (solution taken from https://cmake.org/Wiki/CMake_FAQ#How_do_I_make_my_shared_and_static_libraries_have_the_same_root_name.2C_but_different_suffixes.3F)
-# 
+#
 # Making shared and static libraries have the same root name, but different suffixes
 SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 # Now the library target "curlpp_static" will be named "curlpp.lib" with MS tools.
@@ -103,6 +103,11 @@ SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NA
 # so we add a "lib" prefix (which is default on other platforms anyway):
 SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES PREFIX "lib")
 target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
+target_include_directories(${PROJECT_NAME}_static
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CURL_INCLUDE_DIRS}
+    )
 
 # install headers
 install(DIRECTORY include/utilspp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/utilspp")


### PR DESCRIPTION
Hi!

I was using your project from an external *CMake* project, and I notice that the directories of the target are not exported to other projects that include yours as `add_subdirectory` and then use `target_link_libraries`. 

For example, in a basic *CMake* example using your library:
```cmake
project(curlpp-example)
cmake_minimum_required(VERSION 3.5)

add_subdirectory("thirdparty/curlpp")
set(CMAKE_CXX_STANDARD 11)
add_executable(${PROJECT_NAME} main.cpp)
target_link_libraries(${PROJECT_NAME} PUBLIC curlpp)
```
I'm not be able to use the *curlpp* includes. (More exaclty, the gcc does not compile with the `-Ipath-to-curlpp`)

Adding the `target_include_directories` in your *CMake* library allows to add the *curlpp* includes path to the compilation when you link against the library at `target_link_libraries`.

I let you know the change in case you want to incorporate it into your project.

Regards.

