### PR TITLE
Feature/allow nondefault install prefix

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,6 +19,8 @@ foreach(Example ${ExamplesFileList})
   get_filename_component(ExampleName ${Example} NAME_WE)
   # Define example executable
   add_executable(${ExampleName} ${Example})
+  # Add curlpp include dir
+  target_include_directories(${ExampleName} PRIVATE ${CURLPP_INCLUDE_DIRS})
   # Link example against curlpp
   target_link_libraries(${ExampleName} ${CURLPP_LDFLAGS})
   # make the meta target depend on this example.

--- a/extras/curlpp.pc.in
+++ b/extras/curlpp.pc.in
@@ -1,13 +1,14 @@
 # This is a comment
 prefix=@prefix@
-exec_prefix=@prefix@
-includedir=@includedir@
+exec_prefix=${prefix}
+includedir=${prefix}/@includedir@
+libdir=${prefix}/@libdir@
 
 Name: curlpp
 Description: cURLpp is a libcurl C++ wrapper
 Version: @VERSION@                           
-Libs: -L@libdir@ -lcurlpp @LDFLAGS@ @LIBS@
-Cflags: -I@includedir@ @CURLPP_CXXFLAGS@
+Libs: -L${libdir} -lcurlpp @LDFLAGS@ @LIBS@
+Cflags: -I${includedir} @CURLPP_CXXFLAGS@
 # libcurl is required as non-private because CurlHandle.inl uses curl_easy_setopt.
 Requires: libcurl
  


### PR DESCRIPTION
These changes allow curlpp to be installed to non-default location.
E.g., by using [CMAKE_INSTALL_PREFIX](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html) configuration variable.
Currently, if I use non-default install prefix for curlpp, then curlpp examples could not be build.
With the proposed changes, I could build curlpp examples using [PKG_CONFIG_PATH ](https://linux.die.net/man/1/pkg-config)or [CMAKE_PREFIX_PATH ](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html)pointing to the directory containing curlpp.pc file.
The changes should also fix #68 . 