### PR TITLE
Add several build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.Po
 *.o
 *.a
+*.so
+*.so.*
 *.la
 *.lo
 *.Plo
@@ -41,7 +43,11 @@ examples/example25
 
 *.exe
 CMakeCache.txt
+cmake_install.cmake
 
 conanbuildinfo.cmake
 conaninfo.txt
 bin/
+
+extras/curlpp-config
+extras/curlpp.pc


### PR DESCRIPTION
I noticed that several files generated during the build process were not in the `.gitignore`.  This commit would add them.

The most notable of these would be Unix shared object files (`.so`). The issue with this kind of file is that there are often numbers after the extension (e.g. `libcurlpp.so.1.0.0`), so a rule ignoring `*.so` wouldn't work. This is why I also added a rule ignoring `*.so.*`.

If there is a preference as to ordering/grouping of ignore rules, please let me know and I would be happy to adjust these additions accordingly.