### PR TITLE
fix bug:'FALSE' was not declared in SetOpt

### DIFF
--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -28,6 +28,14 @@
 #include <iostream>
 
 
+#ifndef TRUE
+#define TRUE true
+#endif
+
+#ifndef FALSE 
+#define FALSE false
+#endif
+
 namespace curlpp
 {
 


### PR DESCRIPTION
compile on ubuntu 18.04

curlpp/src/curlpp/internal/OptionSetter.cpp:207:37: error: ‘FALSE’ was not declared in this scope
  handle->option(CURLOPT_NOPROGRESS, FALSE);
