### PR TITLE
Issue 111: change all examples to eliminate deprecated class.

### DIFF
--- a/examples/example00.cpp
+++ b/examples/example00.cpp
@@ -1,7 +1,7 @@
 /**
 * \file
 * The most simple example.
-* 
+*
 */
 
 #include <curlpp/cURLpp.hpp>
@@ -15,8 +15,11 @@ int main(int, char **)
 {
 	try
 	{
-		// That's all that is needed to do cleanup of used resources (RAII style).
-		curlpp::Cleanup myCleanup;
+		// This is marked deprecated.
+		// curlpp::Cleanup myCleanup;
+
+		// Use this instead.
+		curlpp::initialize();
 
 		// Our request to be sent.
 		curlpp::Easy myRequest;
@@ -38,6 +41,9 @@ int main(int, char **)
 	{
 		std::cout << e.what() << std::endl;
 	}
-    
-  return 0;
+
+	// :Cleanup is deprecated, so do this for cleanup.
+	curlpp::terminate();
+
+	return 0;
 }

--- a/examples/example01.cpp
+++ b/examples/example01.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Setting and copying options.
-* 
+*
 */
 
 
@@ -42,14 +42,18 @@ namespace
 const long MyPort = 80;
 }
 
-/** 
+/**
  * This example is made to show you how you can use the Options.
  */
 int main(int, char **)
 {
 	try
 	{
-		curlpp::Cleanup myCleanup;
+		// This is marked deprecated.
+		// curlpp::Cleanup myCleanup;
+
+		// Use this instead.
+		curlpp::initialize();
 
 		// First easy example.
 		{
@@ -65,11 +69,11 @@ int main(int, char **)
 
 		// More elaborate example.
 		{
-		  // What the previous example done there was simply 
+		  // What the previous example done there was simply
 		  // to create a curlpp::Easy class, which is the basic
 		  // object in cURLpp, and then set the Url option.
-		  // curlpp::options classes are the primitives that allow to specify 
-		  // values to the requests. 
+		  // curlpp::options classes are the primitives that allow to specify
+		  // values to the requests.
 		  curlpp::options::Url myUrl(std::string("http://example.com"));
 		  curlpp::Easy myRequest;
 		  myRequest.setOpt(myUrl);
@@ -81,7 +85,7 @@ int main(int, char **)
 		  myRequest.perform();
 
 		  // If we wanted to put the content of the URL within a string stream
-		  // (or any type of std::ostream, for that matter), like the first example, 
+		  // (or any type of std::ostream, for that matter), like the first example,
 		  // we would use the WriteStrem option like this:
 		  std::ostringstream os;
 		  curlpp::options::WriteStream ws(&os);
@@ -112,23 +116,23 @@ int main(int, char **)
 		myRequest.setOpt(*mytest);
 
 		// You can reuse the base option for other type of option
-		// and set the option to the request. but first, don't forget 
-		// to delete the previous memory. You can delete it since the 
+		// and set the option to the request. but first, don't forget
+		// to delete the previous memory. You can delete it since the
 		// option is internally duplicated for the request.
 		delete mytest;
 		mytest = myPort.clone();
 		myRequest.setOpt(*mytest);
 		delete mytest;
 
-		// You can clone an option directly to the same type of 
+		// You can clone an option directly to the same type of
 		// option.
 		curlpp::options::Url *myUrl3 = myUrl.clone();
 		myRequest.setOpt(myUrl3);
-		// Now myUrl3 is owned by the request we will NOT use 
+		// Now myUrl3 is owned by the request we will NOT use
 		// it anymore.
 
 
-		// You don't need to declare an option if you just want 
+		// You don't need to declare an option if you just want
 		// to use it once.
 		myRequest.setOpt(curlpp::options::Url("example.com"));
 
@@ -166,6 +170,9 @@ int main(int, char **)
 	{
 		std::cout << e.what() << std::endl;
 	}
-    
-  return 0;
+	
+	// :Cleanup is deprecated, so do this for cleanup.
+	curlpp::terminate();
+
+	return 0;
 }

--- a/examples/example02.cpp
+++ b/examples/example02.cpp
@@ -1,22 +1,22 @@
 /*
 *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
-*    
+*
 *    Permission is hereby granted, free of charge, to any person obtaining
-*    a copy of this software and associated documentation files 
-*    (curlpp), to deal in the Software without restriction, 
+*    a copy of this software and associated documentation files
+*    (curlpp), to deal in the Software without restriction,
 *    including without limitation the rights to use, copy, modify, merge,
 *    publish, distribute, sublicense, and/or sell copies of the Software,
-*    and to permit persons to whom the Software is furnished to do so, 
+*    and to permit persons to whom the Software is furnished to do so,
 *    subject to the following conditions:
-*    
+*
 *    The above copyright notice and this permission notice shall be included
 *    in all copies or substantial portions of the Software.
-*    
+*
 *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
-*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
@@ -37,7 +37,7 @@
 #include <curlpp/Easy.hpp>
 #include <curlpp/Options.hpp>
 #include <curlpp/Exception.hpp>
- 
+
 /*
    anonymous namespace to prevent name clash in case other examples using the same global entities
    would be compiled in the same project
@@ -59,8 +59,8 @@ int main(int argc, char *argv[])
 {
 	if(argc != 3)
 	{
-		std::cerr << "Example 2: Missing argument" << std::endl 
-							<< "Example 2: Usage: example02 url string-to-send" 
+		std::cerr << "Example 2: Missing argument" << std::endl
+							<< "Example 2: Usage: example02 url string-to-send"
 							<< std::endl;
 		return EXIT_FAILURE;
 	}
@@ -72,12 +72,12 @@ int main(int argc, char *argv[])
 	char buf[50];
 	try
 	{
-		curlpp::Cleanup cleaner;
+        curlpp::initialize();
 		curlpp::Easy request;
 
 		std::list<std::string> headers;
-		headers.push_back("Content-Type: text/*"); 
-		sprintf(buf, "Content-Length: %d", size); 
+		headers.push_back("Content-Type: text/*");
+		sprintf(buf, "Content-Length: %d", size);
 		headers.push_back(buf);
 
 		using namespace curlpp::Options;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
 	{
 		std::cout << e.what() << std::endl;
 	}
+    curlpp::terminate();
 
 	return 0;
 }
-

--- a/examples/example03.cpp
+++ b/examples/example03.cpp
@@ -1,22 +1,22 @@
 /*
 *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
-*    
+*
 *    Permission is hereby granted, free of charge, to any person obtaining
-*    a copy of this software and associated documentation files 
-*    (curlpp), to deal in the Software without restriction, 
+*    a copy of this software and associated documentation files
+*    (curlpp), to deal in the Software without restriction,
 *    including without limitation the rights to use, copy, modify, merge,
 *    publish, distribute, sublicense, and/or sell copies of the Software,
-*    and to permit persons to whom the Software is furnished to do so, 
+*    and to permit persons to whom the Software is furnished to do so,
 *    subject to the following conditions:
-*    
+*
 *    The above copyright notice and this permission notice shall be included
 *    in all copies or substantial portions of the Software.
-*    
+*
 *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
-*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
@@ -50,8 +50,8 @@ int main(int argc, char *argv[])
 
 	if(argc != 2)
 	{
-		std::cerr	<< "Example 3: Wrong number of arguments" << std::endl 
-							<< "Example 3: Usage: example3 url" 
+		std::cerr	<< "Example 3: Wrong number of arguments" << std::endl
+							<< "Example 3: Usage: example3 url"
 							<< std::endl;
 		return EXIT_FAILURE;
 	}
@@ -59,9 +59,9 @@ int main(int argc, char *argv[])
 
 	MyWindow myWindow;
 
-	try 
+	try
 	{
-		curlpp::Cleanup cleaner;
+		curlpp::initialize();
 		curlpp::Easy request;
 
 		using namespace curlpp::Options;
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 		request.perform();
 	}
 
-	catch ( curlpp::LogicError & e ) 
+	catch ( curlpp::LogicError & e )
 	{
 		std::cout << e.what() << std::endl;
 	}
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
 	{
 		std::cout << e.what() << std::endl;
 	}
+	curlpp::terminate();
 
 	return 0;
 }
-

--- a/examples/example04.cpp
+++ b/examples/example04.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Getting options using curlpp::infos.
-* 
+*
 */
 
 
@@ -35,22 +35,22 @@
 #include <curlpp/Options.hpp>
 #include <curlpp/Exception.hpp>
 #include <curlpp/Infos.hpp>
- 
+
 
 int main(int argc, char *argv[])
 {
 	if(argc != 2)
 	{
-		std::cerr << "Example 04: Wrong number of arguments" << std::endl 
-			<< "Example 04: Usage: example04 url" 
+		std::cerr << "Example 04: Wrong number of arguments" << std::endl
+			<< "Example 04: Usage: example04 url"
 			<< std::endl;
 		return EXIT_FAILURE;
 	}
 	char *url = argv[1];
 
-	try 
+	try
 	{
-		curlpp::Cleanup cleaner;
+        curlpp::initialize();
 		curlpp::Easy request;
 
 		using namespace curlpp::Options;
@@ -64,16 +64,16 @@ int main(int argc, char *argv[])
 		std::cout << "Effective URL: " << effURL << std::endl;
 
 		//other way to retreive URL
-		std::cout << std::endl 
-			<< "Effective URL: " 
+		std::cout << std::endl
+			<< "Effective URL: "
 			<< curlpp::infos::EffectiveUrl::get(request)
 			<< std::endl;
 
-		std::cout << "Response code: " 
-			<< curlpp::infos::ResponseCode::get(request) 
+		std::cout << "Response code: "
+			<< curlpp::infos::ResponseCode::get(request)
 			<< std::endl;
 
-		std::cout << "SSL engines: " 
+		std::cout << "SSL engines: "
 			<< curlpp::infos::SslEngines::get(request)
 			<< std::endl;
 	}
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 	catch ( curlpp::RuntimeError & e ) {
 		std::cout << e.what() << std::endl;
 	}
+    curlpp::terminate();
 
 	return 0;
 }
-

--- a/examples/example05.cpp
+++ b/examples/example05.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Write function using free function as a callback.
-* 
+*
 */
 
 
@@ -54,24 +54,24 @@ size_t WriteMemoryCallback(char* ptr, size_t size, size_t nmemb)
 {
   // Calculate the real size of the incoming buffer
   size_t realsize = size * nmemb;
-  
+
   // (Re)Allocate memory for the buffer
   m_pBuffer = (char*) Realloc(m_pBuffer, m_Size + realsize);
-  
+
   // Test if Buffer is initialized correctly & copy memory
   if (m_pBuffer == NULL) {
     realsize = 0;
   }
-  
+
   memcpy(&(m_pBuffer[m_Size]), ptr, realsize);
   m_Size += realsize;
-  
+
   // return the real size of the buffer...
   return realsize;
 };
 
 
-void print() 
+void print()
 {
 	std::cout << "Size: " << m_Size << std::endl;
 	std::cout << "Content: " << std::endl << m_pBuffer << std::endl;
@@ -84,8 +84,8 @@ int main(int argc, char *argv[])
 
 	if(argc != 2)
 	{
-		std::cerr << "Example 05: Wrong number of arguments" << std::endl 
-			<< "Example 05: Usage: example05 url" 
+		std::cerr << "Example 05: Wrong number of arguments" << std::endl
+			<< "Example 05: Usage: example05 url"
 			<< std::endl;
 		return EXIT_FAILURE;
 	}
@@ -93,10 +93,10 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		curlpp::Cleanup cleaner;
+        curlpp::initialize();
 		curlpp::Easy request;
 
-		// Set the writer callback to enable cURL 
+		// Set the writer callback to enable cURL
 		// to write result in a memory area
 		curlpp::types::WriteFunctionFunctor functor(WriteMemoryCallback);
 		curlpp::options::WriteFunction *test = new curlpp::options::WriteFunction(functor);
@@ -117,4 +117,5 @@ int main(int argc, char *argv[])
 	{
 		std::cout << e.what() << std::endl;
 	}
+    curlpp::terminate();
 }

--- a/examples/example06.cpp
+++ b/examples/example06.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * WriteFunction option using functor as a callback.
-* 
+*
 */
 
 
@@ -86,7 +86,7 @@ public:
 	};
 
 
-	void print() 
+	void print()
 	{
 		std::cout << "Size: " << m_Size << std::endl;
 		std::cout << "Content: " << std::endl << m_pBuffer << std::endl;
@@ -102,8 +102,8 @@ int main(int argc, char *argv[])
 {
 	if(argc != 2)
 	{
-		std::cerr << "Example 06: Wrong number of arguments" << std::endl 
-			<< "Example 06: Usage: example06 url" 
+		std::cerr << "Example 06: Wrong number of arguments" << std::endl
+			<< "Example 06: Usage: example06 url"
 			<< std::endl;
 		return EXIT_FAILURE;
 	}
@@ -111,12 +111,12 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		curlpp::Cleanup cleaner;
+		curlpp::initialize();
 		curlpp::Easy request;
 
 		WriterMemoryClass mWriterChunk;
 
-		// Set the writer callback to enable cURL 
+		// Set the writer callback to enable cURL
 		// to write result in a memory area
 		using namespace std::placeholders;
 		curlpp::types::WriteFunctionFunctor functor = std::bind(&WriterMemoryClass::WriteMemoryCallback, &mWriterChunk, _1, _2, _3);
@@ -131,14 +131,15 @@ int main(int argc, char *argv[])
 
 		mWriterChunk.print();
 	}
-	
+
 	catch ( curlpp::LogicError & e )
 	{
 		std::cout << e.what() << std::endl;
 	}
-	
+
 	catch ( curlpp::RuntimeError & e )
 	{
 		std::cout << e.what() << std::endl;
 	}
+	curlpp::terminate();
 }

--- a/examples/example07.cpp
+++ b/examples/example07.cpp
@@ -1,7 +1,7 @@
 /**
 * \file
 * Cookies.
-* 
+*
 */
 
 #include <string>
@@ -117,7 +117,7 @@ main(void)
 {
 	try
 	{
-		curlpp::Cleanup myCleanup;
+        curlpp::initialize();
 		curlpp::Easy exEasy;
 		std::vector<std::string> cookieList;
 
@@ -171,4 +171,5 @@ main(void)
 		std::cout << e.what() << std::endl;
 		exit(EXIT_FAILURE);
 	}
+    curlpp::terminate();
 }

--- a/examples/example08.cpp
+++ b/examples/example08.cpp
@@ -1,22 +1,22 @@
 /*
 *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
-*    
+*
 *    Permission is hereby granted, free of charge, to any person obtaining
-*    a copy of this software and associated documentation files 
-*    (curlpp), to deal in the Software without restriction, 
+*    a copy of this software and associated documentation files
+*    (curlpp), to deal in the Software without restriction,
 *    including without limitation the rights to use, copy, modify, merge,
 *    publish, distribute, sublicense, and/or sell copies of the Software,
-*    and to permit persons to whom the Software is furnished to do so, 
+*    and to permit persons to whom the Software is furnished to do so,
 *    subject to the following conditions:
-*    
+*
 *    The above copyright notice and this permission notice shall be included
 *    in all copies or substantial portions of the Software.
-*    
+*
 *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
-*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
@@ -24,7 +24,7 @@
 /**
 * \file
 * DebugFunction option using functor.
-* 
+*
 */
 
 
@@ -34,7 +34,7 @@
 #include <curlpp/Easy.hpp>
 #include <curlpp/Options.hpp>
 #include <curlpp/Exception.hpp>
- 
+
 
 
 class MyWindow
@@ -55,8 +55,8 @@ int main(int argc, char *argv[])
 {
 	if(argc != 2)
 	{
-		std::cerr << "Example 8: Wrong number of arguments" << std::endl 
-			<< "Example 8: Usage: example8 url" 
+		std::cerr << "Example 8: Wrong number of arguments" << std::endl
+			<< "Example 8: Usage: example8 url"
 			<< std::endl;
 		return EXIT_FAILURE;
 	}
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		curlpp::Cleanup cleaner;
+        curlpp::initialize();
 		curlpp::Easy request;
 
 		using namespace curlpp::Options;
@@ -93,6 +93,6 @@ int main(int argc, char *argv[])
 		std::cout << e.what() << std::endl;
 	}
 
+    curlpp::terminate();
 	return 0;
 }
-

--- a/examples/example09.cpp
+++ b/examples/example09.cpp
@@ -1,22 +1,22 @@
 /*
 *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
-*    
+*
 *    Permission is hereby granted, free of charge, to any person obtaining
-*    a copy of this software and associated documentation files 
-*    (curlpp), to deal in the Software without restriction, 
+*    a copy of this software and associated documentation files
+*    (curlpp), to deal in the Software without restriction,
 *    including without limitation the rights to use, copy, modify, merge,
 *    publish, distribute, sublicense, and/or sell copies of the Software,
-*    and to permit persons to whom the Software is furnished to do so, 
+*    and to permit persons to whom the Software is furnished to do so,
 *    subject to the following conditions:
-*    
+*
 *    The above copyright notice and this permission notice shall be included
 *    in all copies or substantial portions of the Software.
-*    
+*
 *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
-*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
@@ -24,7 +24,7 @@
 /**
 * \file
 * DebugFunction option using functor.
-* 
+*
 */
 
 
@@ -54,25 +54,25 @@ int main(int argc, char *argv[])
 {
   if(argc != 2)
 	{
-    std::cerr << "Example 9: Wrong number of arguments" << std::endl 
-	      << "Example 9: Usage: example9 url" 
+    std::cerr << "Example 9: Wrong number of arguments" << std::endl
+	      << "Example 9: Usage: example9 url"
 	      << std::endl;
     return EXIT_FAILURE;
   }
   char *url = argv[1];
-     
+
   MyWindow myWindow;
   try
   {
-      curlpp::Cleanup cleaner;
+	  curlpp::initialize();
       curlpp::Easy request;
-      
+
       using namespace curlpp::Options;
       request.setOpt(Verbose(true));
       using namespace std::placeholders;
       request.setOpt(DebugFunction(std::bind(&MyWindow::writeDebug, &myWindow, _1, _2, _3)));
       request.setOpt(Url(url));
-      
+
       request.perform();
   }
 
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 	{
     std::cout << e.what() << std::endl;
   }
-  
+
+  curlpp::terminate();
   return 0;
 }
-

--- a/examples/example10.cpp
+++ b/examples/example10.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -25,7 +25,7 @@
 * \file
 * WriteFunction option using functor.
 * Writing to FILE*
-* 
+*
 */
 
 
@@ -40,7 +40,7 @@
 
 #define MAX_FILE_LENGTH 20000
 
-size_t 
+size_t
 FileCallback(FILE *f, char* ptr, size_t size, size_t nmemb)
 {
 	return fwrite(ptr, size, nmemb, f);
@@ -51,8 +51,8 @@ int main(int argc, char *argv[])
 {
 	if(argc != 3)
 	{
-		std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
-			<< argv[0] << ": Usage: " << " url file" 
+		std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
+			<< argv[0] << ": Usage: " << " url file"
 			<< std::endl;
 
 		return EXIT_FAILURE;
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		curlpp::Cleanup cleaner;
+		curlpp::initialize();
 		curlpp::Easy request;
 
 		// Set the writer callback to enable cURL to write result in a memory area
@@ -82,6 +82,7 @@ int main(int argc, char *argv[])
 		request.setOpt(new curlpp::options::Verbose(true));
 		request.perform();
 
+		curlpp::terminate();
 		return EXIT_SUCCESS;
 	}
 
@@ -95,5 +96,6 @@ int main(int argc, char *argv[])
 		std::cout << e.what() << std::endl;
 	}
 
+	curlpp::terminate();
 	return EXIT_FAILURE;
 }

--- a/examples/example11.cpp
+++ b/examples/example11.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -25,7 +25,7 @@
 * \file
 * WriteFunction option using free function.
 * Writing to FILE*
-* 
+*
 */
 
 #include <curlpp/cURLpp.hpp>
@@ -51,8 +51,8 @@ int main(int argc, char *argv[])
 {
 	if(argc < 2)
 	{
-		std::cerr << "Example 11: Wrong number of arguments" << std::endl 
-			<< "Example 11: Usage: example11 url [file]" 
+		std::cerr << "Example 11: Wrong number of arguments" << std::endl
+			<< "Example 11: Usage: example11 url [file]"
 			<< std::endl;
 		return EXIT_FAILURE;
 	}
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		curlpp::Cleanup cleaner;
+		curlpp::initialize();
 		curlpp::Easy request;
 
 		/// Set the writer callback to enable cURL to write result in a memory area
@@ -81,9 +81,9 @@ int main(int argc, char *argv[])
 			  fprintf(stderr, "%s/n", strerror(errno));
 			  return EXIT_FAILURE;
 			}
-		} 
+		}
 
-		curlpp::OptionTrait<void *, CURLOPT_WRITEDATA> 
+		curlpp::OptionTrait<void *, CURLOPT_WRITEDATA>
 			myData(file);
 
 		request.setOpt(myFunction);
@@ -104,4 +104,5 @@ int main(int argc, char *argv[])
 	{
 		std::cout << e.what() << std::endl;
 	}
+	curlpp::terminate();
 }

--- a/examples/example12.cpp
+++ b/examples/example12.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Simple POST demo.
-* 
+*
 */
 
 
@@ -39,30 +39,30 @@
 int main(int argc, char *argv[])
 {
   if(argc < 2) {
-    std::cerr << "Example 11: Wrong number of arguments" << std::endl 
-	      << "Example 11: Usage: example12 url" 
+    std::cerr << "Example 11: Wrong number of arguments" << std::endl
+	      << "Example 11: Usage: example12 url"
 	      << std::endl;
     return EXIT_FAILURE;
   }
-  
+
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
-    
-    request.setOpt(new curlpp::options::Url(url)); 
-    request.setOpt(new curlpp::options::Verbose(true)); 
-    
-    std::list<std::string> header; 
-    header.push_back("Content-Type: application/octet-stream"); 
-    
-    request.setOpt(new curlpp::options::HttpHeader(header)); 
-    
+
+    request.setOpt(new curlpp::options::Url(url));
+    request.setOpt(new curlpp::options::Verbose(true));
+
+    std::list<std::string> header;
+    header.push_back("Content-Type: application/octet-stream");
+
+    request.setOpt(new curlpp::options::HttpHeader(header));
+
     request.setOpt(new curlpp::options::PostFields("abcd"));
     request.setOpt(new curlpp::options::PostFieldSize(5));
-    
-    request.perform(); 
+
+    request.perform();
   }
   catch ( curlpp::LogicError & e ) {
     std::cout << e.what() << std::endl;
@@ -71,5 +71,6 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
+  curlpp::terminate();
   return EXIT_SUCCESS;
 }

--- a/examples/example13.cpp
+++ b/examples/example13.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2006> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Simple Multi demo.
-* 
+*
 */
 
 
@@ -45,57 +45,57 @@
 int main(int argc, char *argv[])
 {
   if(argc < 3) {
-    std::cerr << "Example 13: Wrong number of arguments" << std::endl 
-	      << "Example 13: Usage: example13 url1 url2" 
+    std::cerr << "Example 13: Wrong number of arguments" << std::endl
+	      << "Example 13: Usage: example13 url1 url2"
 	      << std::endl;
     return EXIT_FAILURE;
   }
-  
+
   char *url1 = argv[1];
   char *url2 = argv[2];
-  
+
   try {
-    curlpp::Cleanup cleaner;
-    
+    curlpp::initialize();
+
     curlpp::Easy request1;
     curlpp::Easy request2;
-    
-    request1.setOpt(new curlpp::options::Url(url1)); 
-    request1.setOpt(new curlpp::options::Verbose(true)); 
-    
-    request2.setOpt(new curlpp::options::Url(url2)); 
-    request2.setOpt(new curlpp::options::Verbose(true)); 
-    
+
+    request1.setOpt(new curlpp::options::Url(url1));
+    request1.setOpt(new curlpp::options::Verbose(true));
+
+    request2.setOpt(new curlpp::options::Url(url2));
+    request2.setOpt(new curlpp::options::Verbose(true));
+
     int nbLeft;
     curlpp::Multi requests;
     requests.add(&request1);
     requests.add(&request2);
-    
+
     /* we start some action by calling perform right away */
     while(!requests.perform(&nbLeft)) {};
-    
+
     while(nbLeft) {
       struct timeval timeout;
       int rc; /* select() return code */
-      
+
       fd_set fdread;
       fd_set fdwrite;
       fd_set fdexcep;
       int maxfd;
-      
+
       FD_ZERO(&fdread);
       FD_ZERO(&fdwrite);
       FD_ZERO(&fdexcep);
-      
+
       /* set a suitable timeout to play around with */
       timeout.tv_sec = 1;
       timeout.tv_usec = 0;
-      
+
       /* get file descriptors from the transfers */
       requests.fdset(&fdread, &fdwrite, &fdexcep, &maxfd);
-      
+
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
-      
+
       switch(rc) {
       case -1:
 	/* select error */
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 	break;
       }
     }
-    
+
     std::cout << "NB lefts: " << nbLeft << std::endl;
   }
   catch ( curlpp::LogicError & e ) {
@@ -119,7 +119,6 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
+  curlpp::terminate();
   return EXIT_SUCCESS;
 }
-
-  

--- a/examples/example14.cpp
+++ b/examples/example14.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2006> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Multi demo.
-* 
+*
 */
 
 #include <iostream>
@@ -44,55 +44,55 @@
 int main(int argc, char *argv[])
 {
   if(argc < 3) {
-    std::cerr << "Example 13: Wrong number of arguments" << std::endl 
-	      << "Example 13: Usage: example13 url1 url2" 
+    std::cerr << "Example 13: Wrong number of arguments" << std::endl
+	      << "Example 13: Usage: example13 url1 url2"
 	      << std::endl;
     return EXIT_FAILURE;
   }
-  
+
   char *url1 = argv[1];
   char *url2 = argv[2];
-  
+
   try {
-    curlpp::Cleanup cleaner;
-    
+    curlpp::initialize();
+
     curlpp::Easy request1;
     curlpp::Easy request2;
-    
-    request1.setOpt(new curlpp::options::Url(url1)); 
-    request1.setOpt(new curlpp::options::Verbose(true)); 
-    
-    request2.setOpt(new curlpp::options::Url(url2)); 
-    request2.setOpt(new curlpp::options::Verbose(true)); 
-    
+
+    request1.setOpt(new curlpp::options::Url(url1));
+    request1.setOpt(new curlpp::options::Verbose(true));
+
+    request2.setOpt(new curlpp::options::Url(url2));
+    request2.setOpt(new curlpp::options::Verbose(true));
+
     int nbLeft;
     curlpp::Multi requests;
     requests.add(&request1);
     requests.add(&request2);
-    
+
     /* we start some action by calling perform right away */
     while(!requests.perform(&nbLeft)) {};
-    
+
     while(nbLeft) {
       struct timeval timeout;
       int rc; /* select() return code */
-      
+
       fd_set fdread;
       fd_set fdwrite;
       fd_set fdexcep;
       int maxfd;
-      
+
       FD_ZERO(&fdread);
       FD_ZERO(&fdwrite);
       FD_ZERO(&fdexcep);
-      
+
       /* set a suitable timeout to play around with */
       timeout.tv_sec = 1;
       timeout.tv_usec = 0;
-      
+
       /* get file descriptors from the transfers */
       requests.fdset(&fdread, &fdwrite, &fdexcep, &maxfd);
-      
+
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
       switch(rc) {
       case -1:
@@ -110,11 +110,11 @@ int main(int argc, char *argv[])
 	break;
       }
     }
-    
+
     std::cout << "NB lefts: " << nbLeft << std::endl;
 
     /* See how the transfers went */
-    /* 
+    /*
        Multi::info returns a list of:
        std::pair< curlpp::Easy, curlpp::Multi::Info >
     */
@@ -141,7 +141,6 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
+  curlpp::terminate();
   return EXIT_SUCCESS;
 }
-
-  

--- a/examples/example15.cpp
+++ b/examples/example15.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Using options.
-* 
+*
 */
 
 
@@ -38,24 +38,25 @@
 
 int main(int, char **)
 {
-  try
-  {
-      curlpp::Cleanup myCleanup;
-      
-      // Creation of the URL option.
-      curlpp::Easy myRequest;
-      myRequest.setOpt(new curlpp::options::Url(std::string("https://example.com")));
-      myRequest.setOpt(new curlpp::options::SslEngineDefault());
-      myRequest.perform();
-    }
-  catch( curlpp::RuntimeError &e )
+    try
     {
-      std::cout << e.what() << std::endl;
+        curlpp::initialize();
+
+        // Creation of the URL option.
+        curlpp::Easy myRequest;
+        myRequest.setOpt(new curlpp::options::Url(std::string("https://example.com")));
+        myRequest.setOpt(new curlpp::options::SslEngineDefault());
+        myRequest.perform();
     }
-  catch( curlpp::LogicError &e )
+    catch( curlpp::RuntimeError &e )
     {
-      std::cout << e.what() << std::endl;
+        std::cout << e.what() << std::endl;
     }
-    
-  return 0;
+    catch( curlpp::LogicError &e )
+    {
+        std::cout << e.what() << std::endl;
+    }
+
+    curlpp::terminate();
+    return 0;
 }

--- a/examples/example16.cpp
+++ b/examples/example16.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Simple POST demo.
-* 
+*
 */
 
 
@@ -40,32 +40,32 @@
 int main(int argc, char *argv[])
 {
   if(argc < 2) {
-    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
+    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
 	      << "Usage: " << argv[0] << " url"
 	      << std::endl;
     return EXIT_FAILURE;
   }
-  
+
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
-    
-    request.setOpt(new curlpp::options::Url(url)); 
-    request.setOpt(new curlpp::options::Verbose(true)); 
-    
-    std::list<std::string> header; 
-    header.push_back("Content-Type: application/octet-stream"); 
-    
-    request.setOpt(new curlpp::options::HttpHeader(header)); 
-    
+
+    request.setOpt(new curlpp::options::Url(url));
+    request.setOpt(new curlpp::options::Verbose(true));
+
+    std::list<std::string> header;
+    header.push_back("Content-Type: application/octet-stream");
+
+    request.setOpt(new curlpp::options::HttpHeader(header));
+
     request.setOpt(new curlpp::options::PostFields("abcd"));
     request.setOpt(new curlpp::options::PostFieldSize(5));
 
     request.setOpt(new curlpp::options::UserPwd("user:password"));
-    
-    request.perform(); 
+
+    request.perform();
   }
   catch ( curlpp::LogicError & e ) {
     std::cout << e.what() << std::endl;
@@ -74,5 +74,6 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
+  curlpp::terminate();
   return EXIT_SUCCESS;
 }

--- a/examples/example17.cpp
+++ b/examples/example17.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -65,32 +65,34 @@ public:
 
 int main(int argc, char *argv[])
 {
+  int retVal = EXIT_FAILURE;
+
   if(argc != 2) {
-    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
-	      << argv[0] << ": Usage: " << " url " 
+    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
+	      << argv[0] << ": Usage: " << " url "
 	      << std::endl;
     return EXIT_FAILURE;
   }
 
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
 
     MethodClass mObject(&std::cout);
-    
-    // Set the writer callback to enable cURL 
+
+    // Set the writer callback to enable cURL
     // to write result in a memory area
     using namespace std::placeholders;
     curlpp::options::WriteFunction *test = new curlpp::options::WriteFunction(std::bind(&MethodClass::write, &mObject, &request, _1, _2, _3));
     request.setOpt(test);
-    
+
     // Setting the URL to retrive.
     request.setOpt(new curlpp::options::Url(url));
     request.perform();
 
-    return EXIT_SUCCESS;
+    retVal = EXIT_SUCCESS;
   }
   catch ( curlpp::LogicError & e ) {
     std::cout << e.what() << std::endl;
@@ -99,5 +101,6 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
-  return EXIT_FAILURE;
+  curlpp::terminate();
+  return retVal;
 }

--- a/examples/example18.cpp
+++ b/examples/example18.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * WriteFunction using streams.
-* 
+*
 */
 
 
@@ -37,7 +37,7 @@
 #include <curlpp/Exception.hpp>
 #include <curlpp/Infos.hpp>
 
-		
+
 struct MethodClass
 {
 private:
@@ -73,36 +73,37 @@ public:
 
 int main(int argc, char *argv[])
 {
+  int retVal = EXIT_FAILURE;
+
   if(argc != 2) {
-    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
-	      << argv[0] << ": Usage: " << " url " 
+    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
+	      << argv[0] << ": Usage: " << " url "
 	      << std::endl;
     return EXIT_FAILURE;
   }
 
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
 
     std::ostringstream myStream;
     MethodClass mObject(&myStream);
-    
 
-    // Set the writer callback to enable cURL 
+    // Set the writer callback to enable cURL
     // to write result in a memory area
 #ifdef HAVE_BOOST
     curlpp::options::BoostWriteFunction *test = new curlpp::options::BoostWriteFunction(boost::bind(&MethodClass::write, &mObject, &request, _1, _2, _3));
     request.setOpt(test);
 #endif /* HAVE_BOOST */
-    
+
     // Setting the URL to retrive.
     request.setOpt(new curlpp::options::Url(url));
 
     request.perform();
 
-    return EXIT_SUCCESS;
+    retVal = EXIT_SUCCESS;
   }
   catch ( curlpp::LogicError & e ) {
     std::cout << e.what() << std::endl;
@@ -111,5 +112,6 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
-  return EXIT_FAILURE;
+  curlpp::terminate();
+  return retVal;
 }

--- a/examples/example19.cpp
+++ b/examples/example19.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Gazihan Alankus>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Forms demo.
-* 
+*
 */
 
 
@@ -41,28 +41,28 @@
 int main(int argc, char *argv[])
 {
   if(argc < 2) {
-    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
+    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
 	      << "Usage: " << argv[0] << " url"
 	      << std::endl;
     return EXIT_FAILURE;
   }
-  
+
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
-    
-    request.setOpt(new curlpp::options::Url(url)); 
-    //request.setOpt(new curlpp::options::Verbose(true)); 
-    
+
+    request.setOpt(new curlpp::options::Url(url));
+    //request.setOpt(new curlpp::options::Verbose(true));
+
     {
       // Forms takes ownership of pointers!
       curlpp::Forms formParts;
       formParts.push_back(new curlpp::FormParts::Content("name1", "value1"));
       formParts.push_back(new curlpp::FormParts::Content("name2", "value2"));
-      
-      request.setOpt(new curlpp::options::HttpPost(formParts)); 
+
+      request.setOpt(new curlpp::options::HttpPost(formParts));
     }
 
     // The forms have been cloned and are valid for the request, even
@@ -77,5 +77,6 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
+  curlpp::terminate();
   return EXIT_SUCCESS;
 }

--- a/examples/example20.cpp
+++ b/examples/example20.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Using WriteStream option.
-* 
+*
 */
 
 
@@ -39,29 +39,30 @@
 
 int main(int argc, char *argv[])
 {
+  int retVal = EXIT_FAILURE;
   if(argc != 2) {
-    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
-	      << argv[0] << ": Usage: " << " url " 
+    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
+	      << argv[0] << ": Usage: " << " url "
 	      << std::endl;
     return EXIT_FAILURE;
   }
 
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
 
-    // Set the writer callback to enable cURL 
+    // Set the writer callback to enable cURL
     // to write result in a memory area
     request.setOpt(new curlpp::options::WriteStream(&std::cout));
-    
+
     // Setting the URL to retrive.
     request.setOpt(new curlpp::options::Url(url));
 
     request.perform();
 
-    return EXIT_SUCCESS;
+    retVal = EXIT_SUCCESS;
   }
   catch ( curlpp::LogicError & e ) {
     std::cout << e.what() << std::endl;
@@ -70,5 +71,7 @@ int main(int argc, char *argv[])
     std::cout << e.what() << std::endl;
   }
 
-  return EXIT_FAILURE;
+  curlpp::terminate();
+
+  return retVal;
 }

--- a/examples/example21.cpp
+++ b/examples/example21.cpp
@@ -1,22 +1,22 @@
 /*
 *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
-*    
+*
 *    Permission is hereby granted, free of charge, to any person obtaining
-*    a copy of this software and associated documentation files 
-*    (curlpp), to deal in the Software without restriction, 
+*    a copy of this software and associated documentation files
+*    (curlpp), to deal in the Software without restriction,
 *    including without limitation the rights to use, copy, modify, merge,
 *    publish, distribute, sublicense, and/or sell copies of the Software,
-*    and to permit persons to whom the Software is furnished to do so, 
+*    and to permit persons to whom the Software is furnished to do so,
 *    subject to the following conditions:
-*    
+*
 *    The above copyright notice and this permission notice shall be included
 *    in all copies or substantial portions of the Software.
-*    
+*
 *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
-*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+*    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+*    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Using ReadStream option.
-* 
+*
 */
 
 
@@ -38,50 +38,51 @@
 #include <curlpp/Easy.hpp>
 #include <curlpp/Options.hpp>
 #include <curlpp/Exception.hpp>
- 
+
 int main(int argc, char *argv[])
 {
-  if(argc != 3) {
-    std::cerr << "Example 2: Missing argument" << std::endl 
-	      << "Example 2: Usage: example02 url string-to-send" 
-	      << std::endl;
-    return EXIT_FAILURE;
-  }
-  char *url = argv[1];
+    if(argc != 3) {
+        std::cerr << "Example 2: Missing argument" << std::endl
+                  << "Example 2: Usage: example02 url string-to-send"
+                  << std::endl;
+        return EXIT_FAILURE;
+    }
+    char *url = argv[1];
 
-  std::istringstream myStream(argv[2]);
-  int size = myStream.str().size();
-     
-  char buf[50];
-   try
-   {
-      curlpp::Cleanup cleaner;
-      curlpp::Easy request;
+    std::istringstream myStream(argv[2]);
+    int size = myStream.str().size();
 
-      std::list< std::string > headers;
-      headers.push_back("Content-Type: text/*"); 
-      sprintf(buf, "Content-Length: %d", size); 
-      headers.push_back(buf);
-      
-      using namespace curlpp::Options;
-      request.setOpt(new Verbose(true));
-      request.setOpt(new ReadStream(&myStream));
-      request.setOpt(new InfileSize(size));
-      request.setOpt(new Upload(true));
-      request.setOpt(new HttpHeader(headers));
-      request.setOpt(new Url(url));
-       
-      request.perform();
-   }
-   catch ( curlpp::LogicError & e )
-     {
-       std::cout << e.what() << std::endl;
-     }
-   catch ( curlpp::RuntimeError & e )
-     {
-       std::cout << e.what() << std::endl;
-     }
-   
-   return 0;
+    char buf[50];
+    try
+    {
+        curlpp::initialize();
+        curlpp::Easy request;
+
+        std::list< std::string > headers;
+        headers.push_back("Content-Type: text/*");
+        sprintf(buf, "Content-Length: %d", size);
+        headers.push_back(buf);
+
+        using namespace curlpp::Options;
+        request.setOpt(new Verbose(true));
+        request.setOpt(new ReadStream(&myStream));
+        request.setOpt(new InfileSize(size));
+        request.setOpt(new Upload(true));
+        request.setOpt(new HttpHeader(headers));
+        request.setOpt(new Url(url));
+
+        request.perform();
+    }
+    catch ( curlpp::LogicError & e )
+    {
+        std::cout << e.what() << std::endl;
+    }
+    catch ( curlpp::RuntimeError & e )
+    {
+        std::cout << e.what() << std::endl;
+    }
+
+    curlpp::terminate();
+
+    return 0;
 }
-

--- a/examples/example22.cpp
+++ b/examples/example22.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -24,7 +24,7 @@
 /**
 * \file
 * Using options::Url as stream input.
-* 
+*
 */
 
 
@@ -39,17 +39,18 @@
 
 int main(int argc, char *argv[])
 {
+  int retVal = EXIT_FAILURE;
   if(argc != 2) {
-    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
-	      << argv[0] << ": Usage: " << " url " 
+    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
+	      << argv[0] << ": Usage: " << " url "
 	      << std::endl;
     return EXIT_FAILURE;
   }
 
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
 
     // Setting the URL to retrive.
@@ -57,12 +58,12 @@ int main(int argc, char *argv[])
 
     std::cout << request << std::endl;
 
-    // Even easier version. It does the same thing 
+    // Even easier version. It does the same thing
     // but if you need to download only an url,
     // this is the easiest way to do it.
     std::cout << curlpp::options::Url(url) << std::endl;
 
-    return EXIT_SUCCESS;
+    retVal = EXIT_SUCCESS;
   }
   catch ( curlpp::LogicError & e ) {
     std::cout << e.what() << std::endl;
@@ -70,6 +71,7 @@ int main(int argc, char *argv[])
   catch ( curlpp::RuntimeError & e ) {
     std::cout << e.what() << std::endl;
   }
-
-  return EXIT_FAILURE;
+  
+  curlpp::terminate();
+  return retVal;
 }

--- a/examples/example23.cpp
+++ b/examples/example23.cpp
@@ -1,7 +1,7 @@
 /**
 * \file
 * Setting request options using iterators to custom container of curlpp options.
-* 
+*
 */
 
 #include <vector>
@@ -15,12 +15,10 @@ using namespace curlpp::options;
 
 int main(int, char **)
 {
-
 	try
 	{
-
-		// That's all that is needed to do cleanup of used resources (RAII style).
-		curlpp::Cleanup myCleanup;
+		// curlpp::cleanup is deprecated.
+		curlpp::initialize();
 
 		// Our request to be sent.
 		curlpp::Easy myRequest;
@@ -37,9 +35,7 @@ int main(int, char **)
 		// Send request and get a result.
 		// By default the result goes to standard output.
 		myRequest.perform();
-
 	}
-
 
 	catch(curlpp::RuntimeError & e)
 	{
@@ -50,6 +46,7 @@ int main(int, char **)
 	{
 		std::cout << e.what() << std::endl;
 	}
-    
-  return 0;
+
+	curlpp::terminate();
+	return 0;
 }

--- a/examples/example24.cpp
+++ b/examples/example24.cpp
@@ -1,22 +1,22 @@
 /*
  *    Copyright (c) <2002-2005> <Jean-Philippe Barrette-LaPierre>
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining
- *    a copy of this software and associated documentation files 
- *    (curlpp), to deal in the Software without restriction, 
+ *    a copy of this software and associated documentation files
+ *    (curlpp), to deal in the Software without restriction,
  *    including without limitation the rights to use, copy, modify, merge,
  *    publish, distribute, sublicense, and/or sell copies of the Software,
- *    and to permit persons to whom the Software is furnished to do so, 
+ *    and to permit persons to whom the Software is furnished to do so,
  *    subject to the following conditions:
- *    
+ *
  *    The above copyright notice and this permission notice shall be included
  *    in all copies or substantial portions of the Software.
- *    
+ *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  *    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
- *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+ *    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  *    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
@@ -65,33 +65,34 @@ public:
 
 int main(int argc, char *argv[])
 {
+  int retVal = EXIT_FAILURE;
   if(argc != 2) {
-    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl 
-	      << argv[0] << ": Usage: " << " url " 
+    std::cerr << argv[0] << ": Wrong number of arguments" << std::endl
+	      << argv[0] << ": Usage: " << " url "
 	      << std::endl;
     return EXIT_FAILURE;
   }
 
   char *url = argv[1];
-  
+
   try {
-    curlpp::Cleanup cleaner;
+    curlpp::initialize();
     curlpp::Easy request;
 
     MethodClass mObject(&std::cerr);
-    
-    // Set the debug callback to enable cURL 
+
+    // Set the debug callback to enable cURL
     // to write result in a stream
     using namespace std::placeholders;
     curlpp::options::DebugFunction * test = new curlpp::options::DebugFunction(std::bind(&MethodClass::debug, &mObject, &request, _1, _2, _3));
     request.setOpt(test);
-    
+
     // Setting the URL to retrive.
     request.setOpt(new curlpp::options::Url(url));
     request.setOpt(new curlpp::options::Verbose(true));
     request.perform();
 
-    return EXIT_SUCCESS;
+    retVal = EXIT_SUCCESS;
   }
   catch ( curlpp::LogicError & e ) {
     std::cout << e.what() << std::endl;
@@ -99,6 +100,8 @@ int main(int argc, char *argv[])
   catch ( curlpp::RuntimeError & e ) {
     std::cout << e.what() << std::endl;
   }
+
+  curlpp::terminate();
 
   return EXIT_FAILURE;
 }


### PR DESCRIPTION
Use of the curlpp::Cleanup class is commented as deprecated in the include file, but it's being used in all the examples. This commit changes all of them to use

```
curlpp::initialize();
...
curlpp::terminate();
```

In a few places, I also fixed inconsistent indentation within the file, but I didn't try to fix different indentation styles across all the examples.
