### PR TITLE
Fix pedantic warnings about extra ';'

### DIFF
--- a/src/curlpp/Exception.cpp
+++ b/src/curlpp/Exception.cpp
@@ -72,15 +72,15 @@ curlpp::LibcurlLogicError::LibcurlLogicError(const char * reason, CURLcode code)
 
 curlpp::UnsetOption::UnsetOption(const std::string & reason)
     : curlpp::RuntimeError(reason)
-{};
+{}
 
 curlpp::UnsetOption::UnsetOption(const char * reason)
     : curlpp::RuntimeError(reason)
-{};
+{}
 
 curlpp::NotAvailable::NotAvailable()
     : curlpp::LogicError("This option was not available at compile time.")
-{};
+{}
 
 curlpp::UnknowException::UnknowException() 
   : curlpp::RuntimeError("An unknown exception was thrown within a callback")

--- a/src/curlpp/OptionBase.cpp
+++ b/src/curlpp/OptionBase.cpp
@@ -26,10 +26,10 @@
 
 curlpp::OptionBase::OptionBase(CURLoption option)
   : mOption(option)
-{};
+{}
 
 curlpp::OptionBase::~OptionBase()
-{};
+{}
 
 bool curlpp::OptionBase::operator<(const curlpp::OptionBase & rhs) const 
 {

--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -42,7 +42,7 @@ struct Callbacks
 	WriteCallback(char * buffer, size_t size, size_t nitems, internal::CurlHandle * handle)
 	{
 		return handle->executeWriteFunctor(buffer, size, nitems);
-	};
+	}
 
 
 	static size_t
@@ -54,21 +54,21 @@ struct Callbacks
 			realwrote = 0;
 
 		return realwrote;
-	};
+	}
 
 
 	static size_t
 	HeaderCallback(char * buffer, size_t size, size_t nitems, internal::CurlHandle * handle)
 	{
 		return handle->executeHeaderFunctor(buffer, size, nitems);
-	};
+	}
 
 
 	static size_t
 	ReadCallback(char * buffer, size_t size, size_t nitems, internal::CurlHandle * handle)
 	{
 		return handle->executeReadFunctor(buffer, size, nitems);
-	};
+	}
 
 
 	static size_t
@@ -80,7 +80,7 @@ struct Callbacks
 			realread = CURL_READFUNC_ABORT;
 
 		return realread;
-	};
+	}
 
 
 	static int
@@ -91,7 +91,7 @@ struct Callbacks
 											double ulnow)
 	{
 		return handle->executeProgressFunctor(dltotal, dlnow, ultotal, ulnow);
-	};
+	}
 
 
 	static int
@@ -102,7 +102,7 @@ struct Callbacks
 									internal::CurlHandle * handle)
 	{
 		return handle->executeDebugFunctor(type, data, size);
-	};
+	}
 
 
 	static CURLcode 
@@ -111,7 +111,7 @@ struct Callbacks
 										internal::CurlHandle * handle)
 	{
 		return handle->executeSslCtxFunctor(ssl_ctx);
-	};
+	}
 
 };
 
@@ -120,7 +120,7 @@ void OptionSetter<curlpp::Forms, CURLOPT_HTTPPOST>
 ::setOpt(internal::CurlHandle * handle, ParamType value)
 {
 	handle->option(CURLOPT_HTTPPOST, value.cHttpPost());
-};
+}
 
 
 void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_WRITEFUNCTION>
@@ -129,7 +129,7 @@ void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_WRITEFUNCTION>
 	handle->option(CURLOPT_WRITEFUNCTION, Callbacks::WriteCallback);
 	handle->option(CURLOPT_WRITEDATA, handle);
 	handle->setWriteFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -141,7 +141,7 @@ void OptionSetter<curlpp::types::BoostWriteFunction, CURLOPT_WRITEFUNCTION>
 	handle->option(CURLOPT_WRITEDATA, handle);
 	handle->setWriteFunctor(curlpp::types::WriteFunctionFunctor(&value,
 		&curlpp::types::BoostWriteFunction::operator()));
-};
+}
 
 #endif
 
@@ -151,7 +151,7 @@ void OptionSetter<FILE *, CURLOPT_WRITEDATA>
 {
 	handle->option(CURLOPT_WRITEFUNCTION, (void *)NULL);
 	handle->option(CURLOPT_WRITEDATA, value);
-};
+}
 
 
 void OptionSetter<std::ostream *, CURLOPT_WRITEDATA>
@@ -159,7 +159,7 @@ void OptionSetter<std::ostream *, CURLOPT_WRITEDATA>
 {
 	handle->option(CURLOPT_WRITEFUNCTION, (void *)Callbacks::StreamWriteCallback);
 	handle->option(CURLOPT_WRITEDATA, value);
-};
+}
 
 
 void OptionSetter<curlpp::types::ReadFunctionFunctor, CURLOPT_READFUNCTION>
@@ -168,7 +168,7 @@ void OptionSetter<curlpp::types::ReadFunctionFunctor, CURLOPT_READFUNCTION>
 	handle->option(CURLOPT_READFUNCTION, Callbacks::ReadCallback);
 	handle->option(CURLOPT_READDATA, handle);
 	handle->setReadFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -179,7 +179,7 @@ void OptionSetter<curlpp::types::BoostReadFunction, CURLOPT_READFUNCTION>
 	handle->option(CURLOPT_READFUNCTION, Callbacks::ReadCallback);
 	handle->option(CURLOPT_READDATA, handle);
 	handle->setReadFunctor(value);
-};
+}
 
 #endif
 
@@ -189,7 +189,7 @@ void OptionSetter<FILE *, CURLOPT_READDATA>
 {
 	handle->option(CURLOPT_READFUNCTION, (void *)NULL);
 	handle->option(CURLOPT_READDATA, value);
-};
+}
 
 
 
@@ -198,7 +198,7 @@ void OptionSetter<std::istream *, CURLOPT_READDATA>
 {
 	handle->option(CURLOPT_READFUNCTION, (void *)Callbacks::StreamReadCallback);
 	handle->option(CURLOPT_READDATA, value);
-};
+}
 
 
 void OptionSetter<curlpp::types::ProgressFunctionFunctor, CURLOPT_PROGRESSFUNCTION>
@@ -208,7 +208,7 @@ void OptionSetter<curlpp::types::ProgressFunctionFunctor, CURLOPT_PROGRESSFUNCTI
 	handle->option(CURLOPT_PROGRESSFUNCTION, Callbacks::ProgressCallback);
 	handle->option(CURLOPT_PROGRESSDATA, handle);
 	handle->setProgressFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -220,7 +220,7 @@ void OptionSetter<curlpp::types::BoostProgressFunction, CURLOPT_PROGRESSFUNCTION
 	handle->option(CURLOPT_PROGRESSFUNCTION, Callbacks::ProgressCallback);
 	handle->option(CURLOPT_PROGRESSDATA, handle);
 	handle->setProgressFunctor(value);
-};
+}
 
 #endif
 
@@ -231,7 +231,7 @@ void OptionSetter<curlpp::types::WriteFunctionFunctor, CURLOPT_HEADERFUNCTION>
 	handle->option(CURLOPT_HEADERFUNCTION, Callbacks::HeaderCallback);
 	handle->option(CURLOPT_HEADERDATA, handle);
 	handle->setHeaderFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -242,7 +242,7 @@ void OptionSetter<curlpp::types::BoostWriteFunction, CURLOPT_HEADERFUNCTION>
 	handle->option(CURLOPT_HEADERFUNCTION, Callbacks::HeaderCallback);
 	handle->option(CURLOPT_HEADERDATA, handle);
 	handle->setHeaderFunctor(value);
-};
+}
 
 #endif
 
@@ -253,7 +253,7 @@ void OptionSetter<curlpp::types::DebugFunctionFunctor, CURLOPT_DEBUGFUNCTION>
 	handle->option(CURLOPT_DEBUGFUNCTION, Callbacks::DebugCallback);
 	handle->option(CURLOPT_DEBUGDATA, handle);
 	handle->setDebugFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -264,7 +264,7 @@ void OptionSetter<curlpp::types::BoostDebugFunction, CURLOPT_DEBUGFUNCTION>
 	handle->option(CURLOPT_DEBUGFUNCTION, Callbacks::DebugCallback);
 	handle->option(CURLOPT_DEBUGDATA, handle);
 	handle->setDebugFunctor(value);
-};
+}
 
 #endif
 
@@ -275,7 +275,7 @@ void OptionSetter<curlpp::types::SslCtxFunctionFunctor, CURLOPT_SSL_CTX_FUNCTION
 	handle->option(CURLOPT_SSL_CTX_FUNCTION, Callbacks::SslCtxCallback);
 	handle->option(CURLOPT_SSL_CTX_DATA, handle);
 	handle->setSslCtxFunctor(value);
-};
+}
 
 
 #ifdef HAVE_BOOST
@@ -286,7 +286,7 @@ void OptionSetter<curlpp::types::BoostSslCtxFunction, CURLOPT_SSL_CTX_FUNCTION>
 	handle->option(CURLOPT_SSL_CTX_FUNCTION, Callbacks::SslCtxCallback);
 	handle->option(CURLOPT_SSL_CTX_DATA, handle);
 	handle->setSslCtxFunctor(value);
-};
+}
 
 #endif
 


### PR DESCRIPTION
fix gcc 9.3.0 warnings with the message `warning: extra ':' [-Wpedantic]`

After function implementations no `;` is needed after the function block