### PR TITLE
Fix incorrect termination condition of Stream

### DIFF
--- a/include/curlpp/Options.hpp
+++ b/include/curlpp/Options.hpp
@@ -249,6 +249,14 @@ namespace options
 	typedef curlpp::OptionTrait<curl_ftpssl, CURLOPT_FTP_SSL> FtpSsl;
 	typedef curlpp::OptionTrait<curl_ftpauth, CURLOPT_FTPSSLAUTH> FtpSslAuth;
 
+	/**
+	 * SMTP options.
+	 */
+
+	typedef curlpp::OptionTrait<std::string, CURLOPT_MAIL_FROM> MailFrom;
+	typedef curlpp::OptionTrait<std::list<std::string>, CURLOPT_MAIL_RCPT> MailRcpt;
+
+
 
 	/**
 	* Protocol options.

--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -76,7 +76,7 @@ struct Callbacks
 	{
 		stream->read(buffer, static_cast<std::streamsize>(size * nitems));
 		size_t realread = stream->gcount();
-		if(!realread && !(*stream))
+		if (stream->fail() && !stream->eof())
 			realread = CURL_READFUNC_ABORT;
 
 		return realread;


### PR DESCRIPTION
Fix incorrect termination condition of Stream
（StreamReadCallback）