### PR TITLE
Put full paths in pkg-config specification.

### DIFF
--- a/extras/curlpp.pc.in
+++ b/extras/curlpp.pc.in
@@ -1,13 +1,13 @@
 # This is a comment
 prefix=@prefix@
-exec_prefix=@prefix@
-includedir=@includedir@
+exec_prefix=${prefix}
+includedir=${prefix}/@includedir@
+libdir=${exec_prefix}/@libdir@
 
 Name: curlpp
 Description: cURLpp is a libcurl C++ wrapper
 Version: @VERSION@                           
-Libs: -L@libdir@ -lcurlpp @LDFLAGS@ @LIBS@
-Cflags: -I@includedir@ @CURLPP_CXXFLAGS@
+Libs: -L${libdir} -lcurlpp @LDFLAGS@ @LIBS@
+Cflags: -I${includedir} @CURLPP_CXXFLAGS@
 # libcurl is required as non-private because CurlHandle.inl uses curl_easy_setopt.
 Requires: libcurl
- 


### PR DESCRIPTION
Currently, 'pkg-config --cflags curlpp' gives '-Iinclude', which is not good
enough for outside projects to link to this package.

* extras/curlpp.pc.in: use internal variables to make the generated
  specifications more precise.