### PR TITLE
Modernization of Install Logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,12 +104,14 @@ file(GLOB_RECURSE SourceFileList "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
 option(CURLPP_BUILD_SHARED_LIBS "Build shared libraries" ON)
 if(CURLPP_BUILD_SHARED_LIBS)
    add_library(${PROJECT_NAME} SHARED ${HeaderFileList} ${SourceFileList})
+   add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
    target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
    target_link_libraries(${PROJECT_NAME} PUBLIC CURL::libcurl ${CONAN_LIBS})
    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
 endif()
 
 add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
+add_library(${PROJECT_NAME}::${PROJECT_NAME}_static ALIAS ${PROJECT_NAME}_static)
 target_include_directories(${PROJECT_NAME}_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 # Make sure that on unix-platforms shared and static libraries have

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,13 +104,13 @@ file(GLOB_RECURSE SourceFileList "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
 option(CURLPP_BUILD_SHARED_LIBS "Build shared libraries" ON)
 if(CURLPP_BUILD_SHARED_LIBS)
    add_library(${PROJECT_NAME} SHARED ${HeaderFileList} ${SourceFileList})
-   target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-   target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES} ${CONAN_LIBS})
+   target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+   target_link_libraries(${PROJECT_NAME} PUBLIC CURL::libcurl ${CONAN_LIBS})
    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
 endif()
 
 add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
-target_include_directories(${PROJECT_NAME}_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(${PROJECT_NAME}_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 # Make sure that on unix-platforms shared and static libraries have
 # the same root name, but different suffixes.
@@ -126,13 +126,17 @@ SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES PREFIX "lib")
 target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
 
 # install headers
-install(DIRECTORY include/utilspp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/utilspp")
-install(DIRECTORY include/curlpp/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/curlpp")
+install(FILES "${PROJECT_SOURCE_DIR}/cmake/curlppConfig.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/curlpp")
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(CURLPP_BUILD_SHARED_LIBS)
-install(TARGETS ${PROJECT_NAME}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(TARGETS curlpp EXPORT curlppTargets INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
-install(TARGETS ${PROJECT_NAME}_static
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(TARGETS curlpp_static EXPORT curlppTargets INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  
+install(
+    EXPORT curlppTargets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/curlpp"
+    NAMESPACE curlpp::
+)
+

--- a/cmake/curlppConfig.cmake
+++ b/cmake/curlppConfig.cmake
@@ -1,0 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(CURL)
+
+include(${CMAKE_CURRENT_LIST_DIR}/curlppTargets.cmake)


### PR DESCRIPTION
This PR aims to not only install the library & inlcude headers, but also the target definition itself including required dependencies.

This allows Consumer Projects to do the following: 
```cmake
find_package(curlpp)
```
which will use findPackage in the recommended config mode and also ensures that dependencies such as curl are available.

or
```cmake
add_subdirectory(curlpp) # git submodule, FetchContent, CPM, ...
````

And then in any case the target can be linked the same way. This will propagate all neded headers, libraries, dependencies, ...:
```cmake
target_link_libraries(my_target PUBLIC curlpp::curlpp)
```