### PR TITLE
Useless exception check in libcurlVersion()

### DIFF
--- a/src/curlpp/cURLpp.cpp
+++ b/src/curlpp/cURLpp.cpp
@@ -98,11 +98,7 @@ std::string
 curlpp::libcurlVersion()
 {
   char* p = curl_version();
-   if (!p)
-   {
-      throw RuntimeError("unable to get the libcurl version"); //we got an error
-   }
-      
+
    return std::string(p);
 }
 


### PR DESCRIPTION
Hello,
When calling `libcurlVersion()` it checks the return value of `curl_version()` to know whether it throws an error (i.e. a `nullptr`) or not. However, according to libcurl docs, `curl_version()` statically allocates memory which guarantees that the lifetime of that object will remain till the program ends, thus the check for `nullptr` will never reach. This PR removes the additional check.

Docs: https://curl.se/libcurl/c/curl_version.html