### PR TITLE
put down sign-conversion warning

### DIFF
--- a/src/curlpp/internal/OptionSetter.cpp
+++ b/src/curlpp/internal/OptionSetter.cpp
@@ -75,7 +75,7 @@ struct Callbacks
 	StreamReadCallback(char * buffer, size_t size, size_t nitems, std::istream * stream)
 	{
 		stream->read(buffer, static_cast<std::streamsize>(size * nitems));
-		size_t realread = stream->gcount();
+		size_t realread = static_cast<size_t>(stream->gcount());
 		if (stream->fail() && !stream->eof())
 			realread = CURL_READFUNC_ABORT;
 


### PR DESCRIPTION
When compiling as a part of the project, I see this unattended type conversion:
```
$PROJECT_ROOT/build/_deps/curlpp-src/src/curlpp/internal/OptionSetter.cpp: In static member function ‘static size_t curlpp::internal::Callbacks::StreamReadCallback(char*, size_t, size_t, std::istream*)’:
$PROJECT_ROOT/build/_deps/curlpp-src/src/curlpp/internal/OptionSetter.cpp:78:49: error: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘std::streamsize’ {aka ‘long int’} may change the sign of the result [-Werror=sign-conversion]
   78 |                 size_t realread = stream->gcount();
```

To remedy this, I would suggest to ```static_cast``` the ```gcount()``` result into the very ```size_t```.